### PR TITLE
Allow CHANNEL_BUFFER_SIZE to be set by a system property

### DIFF
--- a/src/com/trilead/ssh2/channel/Channel.java
+++ b/src/com/trilead/ssh2/channel/Channel.java
@@ -42,7 +42,7 @@ public class Channel
 
 	static final int CHANNEL_BUFFER_SIZE = Integer.getInteger(
 			Channel.class.getName()+".bufferSize",
-			30000).intValue();
+			128*1024 + 16*1024).intValue();
 
 	/*
 	 * To achieve correctness, the following rules have to be respected when


### PR DESCRIPTION
This buffer size limits the maximum receive window for ssh channels.
30k is much too small for pulling large amounts of data over high
bandwidth-delay-product links.  Allow this constant to be set at JVM
startup time via the property
"com.trilead.ssh2.channel.Channel.bufferSize".
