### PR TITLE
resolve the dequeue hanging when the packets.size=0,packets.wait()wil…

### DIFF
--- a/src/com/trilead/ssh2/auth/AuthenticationManager.java
+++ b/src/com/trilead/ssh2/auth/AuthenticationManager.java
@@ -57,7 +57,7 @@ public class AuthenticationManager implements MessageHandler
 	{
 		synchronized (packets)
 		{
-			while (packets.size() == 0)
+			if (packets.size() == 0)
 			{
 				if (connectionClosed)
 					throw (IOException) new IOException("The connection is closed.").initCause(tm
@@ -65,11 +65,14 @@ public class AuthenticationManager implements MessageHandler
 
 				try
 				{
-					packets.wait();
+					packets.wait(1000*60*2);
 				}
 				catch (InterruptedException ign)
 				{
-                    throw new InterruptedIOException();
+                    throw new InterruptedIOException(ign.getMessage());
+				}
+				if(packets.size()==0){
+					throw new IOException("WAIT 2 MINUTES,WAIT TIMEOUT");
 				}
 			}
 			/* This sequence works with J2ME */


### PR DESCRIPTION
In the method deQueue(), when then packets.size()==0, then the packets.wait(), and no thread will notify packets, this lead to hang bug. I try to make the packets wait 2 minutes, if 2 minutes passed the packets still empty then an exception will throw. This way can deal with the hanging bug
