### PR TITLE
Added support for  HMAC_SHA2_256, HMAC_SHA2_512

### DIFF
--- a/src/com/trilead/ssh2/crypto/digest/MAC.java
+++ b/src/com/trilead/ssh2/crypto/digest/MAC.java
@@ -1,88 +1,147 @@
 
 package com.trilead.ssh2.crypto.digest;
 
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Mac;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.SecretKeySpec;
+
 /**
  * MAC.
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: MAC.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
  */
-public final class MAC
+public final class MAC 
 {
-	Digest mac;
-	int size;
-
-	public final static String[] getMacList()
+    private enum Hmac
 	{
-		/* Higher Priority First */
+        HMAC_MD5("hmac-md5", "HmacMD5", 16), // http://tools.ietf.org/html/rfc4253
+        HMAC_MD5_96("hmac-md5-96", "HmacMD5", 16), // http://tools.ietf.org/html/rfc4253
+        HMAC_SHA1("hmac-sha1", "HmacSHA1", 20), // http://tools.ietf.org/html/rfc4253
+        HMAC_SHA1_96("hmac-sha1-96", "HmacSHA1", 20), // http://tools.ietf.org/html/rfc4253
+        HMAC_SHA2_256("hmac-sha2-256", "HmacSHA256", 32), // http://tools.ietf.org/html/rfc6668
+        HMAC_SHA2_512("hmac-sha2-512", "HmacSHA512", 64); // http://tools.ietf.org/html/rfc6668
 
-		return new String[] { "hmac-sha1-96", "hmac-sha1", "hmac-md5-96", "hmac-md5" };
-	}
+        private String type;
+        private String algorithm;
+        private int length;
 
-	public final static void checkMacList(String[] macs)
-	{
-		for (int i = 0; i < macs.length; i++)
-			getKeyLen(macs[i]);
-	}
-
-	public final static int getKeyLen(String type)
-	{
-		if (type.equals("hmac-sha1"))
-			return 20;
-		if (type.equals("hmac-sha1-96"))
-			return 20;
-		if (type.equals("hmac-md5"))
-			return 16;
-		if (type.equals("hmac-md5-96"))
-			return 16;
-		throw new IllegalArgumentException("Unkown algorithm " + type);
-	}
-
-	public MAC(String type, byte[] key)
-	{
-		if (type.equals("hmac-sha1"))
+        Hmac(String type, String algorithm, int length) 
 		{
-			mac = new HMAC(new SHA1(), key, 20);
-		}
-		else if (type.equals("hmac-sha1-96"))
+            this.type = type;
+            this.algorithm = algorithm;
+            this.length = length;
+        }
+
+        private static Hmac getHmac(String type) 
 		{
-			mac = new HMAC(new SHA1(), key, 12);
-		}
-		else if (type.equals("hmac-md5"))
+            try 
+			{
+                return Hmac.valueOf(type.replaceAll("-", "_").toUpperCase());
+            } 
+			catch (Exception e) 
+			{
+                throw new IllegalArgumentException("Unkown algorithm " + type);
+            }
+        }
+    }
+
+    private static final String[] PRIORITIZED_MAC_LIST = { Hmac.HMAC_SHA2_256.type, Hmac.HMAC_SHA2_512.type,
+            Hmac.HMAC_SHA1_96.type, Hmac.HMAC_SHA1.type, Hmac.HMAC_MD5_96.type, Hmac.HMAC_MD5.type };
+
+    Mac mac;
+    int outSize;
+    int macSize;
+    byte[] buffer;
+
+    public final static String[] getMacList() 
+	{
+        return PRIORITIZED_MAC_LIST;
+    }
+
+    public final static void checkMacList(String[] macs) 
+	{
+        for (int i = 0; i < macs.length; i++)
+            getKeyLen(macs[i]);
+    }
+
+    public final static int getKeyLen(String type) 
+	{
+        return Hmac.getHmac(type).length;
+    }
+
+    public MAC(String type, byte[] key) 
+	{
+        try 
 		{
-			mac = new HMAC(new MD5(), key, 16);
-		}
-		else if (type.equals("hmac-md5-96"))
+            mac = Mac.getInstance(Hmac.getHmac(type).algorithm);
+        } 
+		catch (NoSuchAlgorithmException e) 
 		{
-			mac = new HMAC(new MD5(), key, 12);
-		}
-		else
-			throw new IllegalArgumentException("Unkown algorithm " + type);
+            throw new IllegalArgumentException("Unknown algorithm " + type, e);
+        }
 
-		size = mac.getDigestLength();
-	}
+        macSize = mac.getMacLength();
+        if (type.endsWith("-96")) 
+		{
+            outSize = 12;
+            buffer = new byte[macSize];
+        } 
+		else 
+		{
+            outSize = macSize;
+            buffer = null;
+        }
 
-	public final void initMac(int seq)
+        try 
+		{
+            mac.init(new SecretKeySpec(key, type));
+        } 
+		catch (InvalidKeyException e) 
+		{
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public final void initMac(int seq) 
 	{
-		mac.reset();
-		mac.update((byte) (seq >> 24));
-		mac.update((byte) (seq >> 16));
-		mac.update((byte) (seq >> 8));
-		mac.update((byte) (seq));
-	}
+        mac.reset();
+        mac.update((byte) (seq >> 24));
+        mac.update((byte) (seq >> 16));
+        mac.update((byte) (seq >> 8));
+        mac.update((byte) (seq));
+    }
 
-	public final void update(byte[] packetdata, int off, int len)
+    public final void update(byte[] packetdata, int off, int len)
 	{
-		mac.update(packetdata, off, len);
-	}
+        mac.update(packetdata, off, len);
+    }
 
-	public final void getMac(byte[] out, int off)
+    public final void getMac(byte[] out, int off) 
 	{
-		mac.digest(out, off);
-	}
+        try
+		{
+            if (buffer != null) 
+			{
+                mac.doFinal(buffer, 0);
+                System.arraycopy(buffer, 0, out, off, out.length - off);
+            } 
+			else 
+			{
+                mac.doFinal(out, off);
+            }
+        } 
+		catch (ShortBufferException e) 
+		{
+            throw new IllegalStateException(e);
+        }
+    }
 
-	public final int size()
+    public final int size() 
 	{
-		return size;
-	}
+        return outSize;
+    }
 }


### PR DESCRIPTION
Did this by refactoring the MAC class to use javax.crypto, 
some classes in src/com/trilead/ssh2/crypto/digest/ might not be needed anymore?
