### PR TITLE
[FIXED JENKINS-33021] [Fixed JENKINS-36873] [Fixed JENKINS-31549] Add support for  hmac 256 and 512

### DIFF
--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -10,7 +10,7 @@ import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.PacketIgnore;
 import com.trilead.ssh2.transport.ClientServerHello;
 import com.trilead.ssh2.transport.KexManager;
-import com.trilead.ssh2.transport.TransportManager;
+import com.trilead.ssh2.transport.TransportManagerNew;
 import com.trilead.ssh2.util.TimeoutService;
 import com.trilead.ssh2.util.TimeoutService.TimeoutToken;
 
@@ -102,7 +102,7 @@ public class Connection
 
 	private final int port;
 
-	private TransportManager tm;
+	private TransportManagerNew tm;
 
 	private boolean tcpNoDelay = false;
 

--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -9,7 +9,7 @@ import com.trilead.ssh2.crypto.digest.MACNew;
 import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.PacketIgnore;
 import com.trilead.ssh2.transport.ClientServerHello;
-import com.trilead.ssh2.transport.KexManager;
+import com.trilead.ssh2.transport.KexManagerNew;
 import com.trilead.ssh2.transport.TransportManagerNew;
 import com.trilead.ssh2.util.TimeoutService;
 import com.trilead.ssh2.util.TimeoutService.TimeoutToken;
@@ -86,7 +86,7 @@ public class Connection
 	 */
 	public static synchronized String[] getAvailableServerHostKeyAlgorithms()
 	{
-		return KexManager.getDefaultServerHostkeyAlgorithmList();
+		return KexManagerNew.getDefaultServerHostkeyAlgorithmList();
 	}
 
 	private AuthenticationManager am;

--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -1311,7 +1311,7 @@ public class Connection
 			throw new IllegalArgumentException();
 
 		algos = removeDuplicates(algos);
-		KexManager.checkServerHostkeyAlgorithmsList(algos);
+		KexManagerNew.checkServerHostkeyAlgorithmsList(algos);
 		cryptoWishList.serverHostKeyAlgorithms = algos;
 	}
 

--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -5,7 +5,7 @@ import com.trilead.ssh2.auth.AuthenticationManager;
 import com.trilead.ssh2.channel.ChannelManager;
 import com.trilead.ssh2.crypto.CryptoWishList;
 import com.trilead.ssh2.crypto.cipher.BlockCipherFactory;
-import com.trilead.ssh2.crypto.digest.MAC;
+import com.trilead.ssh2.crypto.digest.MACNew;
 import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.PacketIgnore;
 import com.trilead.ssh2.transport.ClientServerHello;
@@ -75,7 +75,7 @@ public class Connection
 	 */
 	public static synchronized String[] getAvailableMACs()
 	{
-		return MAC.getMacList();
+		return MACNew.getMacList();
 	}
 
 	/**
@@ -1242,7 +1242,7 @@ public class Connection
 		if ((macs == null) || (macs.length == 0))
 			throw new IllegalArgumentException();
 		macs = removeDuplicates(macs);
-		MAC.checkMacList(macs);
+		MACNew.checkMacList(macs);
 		cryptoWishList.c2s_mac_algos = macs;
 	}
 
@@ -1288,7 +1288,7 @@ public class Connection
 			throw new IllegalArgumentException();
 
 		macs = removeDuplicates(macs);
-		MAC.checkMacList(macs);
+		MACNew.checkMacList(macs);
 		cryptoWishList.s2c_mac_algos = macs;
 	}
 

--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -706,7 +706,7 @@ public class Connection
 
 		final TimeoutState state = new TimeoutState();
 
-		tm = new TransportManager(hostname, port);
+		tm = new TransportManagerNew(hostname, port);
 		
 		tm.setConnectionMonitors(connectionMonitors);
 

--- a/src/com/trilead/ssh2/auth/AuthenticationManager.java
+++ b/src/com/trilead/ssh2/auth/AuthenticationManager.java
@@ -35,7 +35,7 @@ public class AuthenticationManager implements MessageHandler
 	boolean authenticated = false;
 	boolean initDone = false;
 
-	public AuthenticationManager(TransportManager tm)
+	public AuthenticationManager(TransportManagerNew tm)
 	{
 		this.tm = tm;
 	}

--- a/src/com/trilead/ssh2/auth/AuthenticationManager.java
+++ b/src/com/trilead/ssh2/auth/AuthenticationManager.java
@@ -5,7 +5,7 @@ import com.trilead.ssh2.crypto.PEMDecoder;
 import com.trilead.ssh2.packets.*;
 import com.trilead.ssh2.signature.*;
 import com.trilead.ssh2.transport.MessageHandler;
-import com.trilead.ssh2.transport.TransportManager;
+import com.trilead.ssh2.transport.TransportManagerNew;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -22,7 +22,7 @@ import java.util.Vector;
  */
 public class AuthenticationManager implements MessageHandler
 {
-	TransportManager tm;
+	TransportManagerNew tm;
 
 	Vector packets = new Vector();
 	boolean connectionClosed = false;

--- a/src/com/trilead/ssh2/channel/Channel.java
+++ b/src/com/trilead/ssh2/channel/Channel.java
@@ -5,7 +5,7 @@ import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.PacketSignal;
 import com.trilead.ssh2.packets.PacketWindowChange;
 import com.trilead.ssh2.packets.Packets;
-import com.trilead.ssh2.transport.TransportManager;
+import com.trilead.ssh2.transport.TransportManagerNew;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -252,7 +252,7 @@ public class Channel
 		this.cm = cm;
 
 		this.localWindow = channelBufferSize;
-		this.localMaxPacketSize = TransportManager.MAX_PACKET_SIZE - 1024; // leave enough slack
+		this.localMaxPacketSize = TransportManagerNew.MAX_PACKET_SIZE - 1024; // leave enough slack
 
 		this.stdinStream = new ChannelOutputStream(this);
 		this.stdout.stream = new ChannelInputStream(this, false);

--- a/src/com/trilead/ssh2/channel/ChannelManager.java
+++ b/src/com/trilead/ssh2/channel/ChannelManager.java
@@ -24,7 +24,7 @@ import com.trilead.ssh2.packets.PacketWindowChange;
 import com.trilead.ssh2.packets.Packets;
 import com.trilead.ssh2.packets.TypesReader;
 import com.trilead.ssh2.transport.MessageHandler;
-import com.trilead.ssh2.transport.TransportManager;
+import com.trilead.ssh2.transport.TransportManagerNew;
 
 /**
  * ChannelManager. Please read the comments in Channel.java.
@@ -40,7 +40,7 @@ public class ChannelManager implements MessageHandler
 
 	private HashMap x11_magic_cookies = new HashMap();
 
-	/*package*/ TransportManager tm;
+	/*package*/ TransportManagerNew tm;
 
 	private Vector channels = new Vector();
 	private int nextLocalChannel = 100;
@@ -54,7 +54,7 @@ public class ChannelManager implements MessageHandler
 
 	private boolean listenerThreadsAllowed = true;
 
-	public ChannelManager(TransportManager tm)
+	public ChannelManager(TransportManagerNew tm)
 	{
 		this.tm = tm;
 		tm.registerMessageHandler(this, 80, 100);

--- a/src/com/trilead/ssh2/crypto/CryptoWishList.java
+++ b/src/com/trilead/ssh2/crypto/CryptoWishList.java
@@ -3,7 +3,7 @@ package com.trilead.ssh2.crypto;
 
 import com.trilead.ssh2.crypto.cipher.BlockCipherFactory;
 import com.trilead.ssh2.crypto.digest.MACNew;
-import com.trilead.ssh2.transport.KexManager;
+import com.trilead.ssh2.transport.KexManagerNew;
 
 
 /**
@@ -14,8 +14,8 @@ import com.trilead.ssh2.transport.KexManager;
  */
 public class CryptoWishList
 {
-	public String[] kexAlgorithms = KexManager.getDefaultKexAlgorithmList();
-	public String[] serverHostKeyAlgorithms = KexManager.getDefaultServerHostkeyAlgorithmList();
+	public String[] kexAlgorithms = KexManagerNew.getDefaultKexAlgorithmList();
+	public String[] serverHostKeyAlgorithms = KexManagerNew.getDefaultServerHostkeyAlgorithmList();
 	public String[] c2s_enc_algos = BlockCipherFactory.getDefaultCipherList();
 	public String[] s2c_enc_algos = BlockCipherFactory.getDefaultCipherList();
 	public String[] c2s_mac_algos = MACNew.getMacList();

--- a/src/com/trilead/ssh2/crypto/CryptoWishList.java
+++ b/src/com/trilead/ssh2/crypto/CryptoWishList.java
@@ -2,7 +2,7 @@
 package com.trilead.ssh2.crypto;
 
 import com.trilead.ssh2.crypto.cipher.BlockCipherFactory;
-import com.trilead.ssh2.crypto.digest.MAC;
+import com.trilead.ssh2.crypto.digest.MACNew;
 import com.trilead.ssh2.transport.KexManager;
 
 
@@ -18,6 +18,6 @@ public class CryptoWishList
 	public String[] serverHostKeyAlgorithms = KexManager.getDefaultServerHostkeyAlgorithmList();
 	public String[] c2s_enc_algos = BlockCipherFactory.getDefaultCipherList();
 	public String[] s2c_enc_algos = BlockCipherFactory.getDefaultCipherList();
-	public String[] c2s_mac_algos = MAC.getMacList();
-	public String[] s2c_mac_algos = MAC.getMacList();
+	public String[] c2s_mac_algos = MACNew.getMacList();
+	public String[] s2c_mac_algos = MACNew.getMacList();
 }

--- a/src/com/trilead/ssh2/crypto/KeyMaterial.java
+++ b/src/com/trilead/ssh2/crypto/KeyMaterial.java
@@ -4,7 +4,7 @@ package com.trilead.ssh2.crypto;
 
 import java.math.BigInteger;
 
-import com.trilead.ssh2.crypto.digest.HashForSSH2Types;
+import com.trilead.ssh2.crypto.digest.HashForSSH2TypesNew;
 
 /**
  * Establishes key material for iv/key/mac (both directions).
@@ -21,7 +21,7 @@ public class KeyMaterial
 	public byte[] integrity_key_client_to_server;
 	public byte[] integrity_key_server_to_client;
 
-	private static byte[] calculateKey(HashForSSH2Types sh, BigInteger K, byte[] H, byte type, byte[] SessionID,
+	private static byte[] calculateKey(HashForSSH2TypesNew sh, BigInteger K, byte[] H, byte type, byte[] SessionID,
 			int keyLength)
 	{
 		byte[] res = new byte[keyLength];
@@ -72,7 +72,7 @@ public class KeyMaterial
 	{
 		KeyMaterial km = new KeyMaterial();
 
-		HashForSSH2Types sh = new HashForSSH2Types(hashAlgo);
+		HashForSSH2TypesNew sh = new HashForSSH2TypesNew(hashAlgo);
 
 		km.initial_iv_client_to_server = calculateKey(sh, K, H, (byte) 'A', SessionID, blockSizeCS);
 

--- a/src/com/trilead/ssh2/crypto/dh/DhExchange.java
+++ b/src/com/trilead/ssh2/crypto/dh/DhExchange.java
@@ -1,129 +1,147 @@
+
 package com.trilead.ssh2.crypto.dh;
 
-import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.KeyFactory;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
+import java.security.SecureRandom;
 
-import javax.crypto.KeyAgreement;
-import javax.crypto.interfaces.DHPrivateKey;
-import javax.crypto.interfaces.DHPublicKey;
-import javax.crypto.spec.DHParameterSpec;
-import javax.crypto.spec.DHPublicKeySpec;
+import com.trilead.ssh2.crypto.digest.HashForSSH2Types;
+import com.trilead.ssh2.log.Logger;
+
 
 /**
- * @author kenny
- *
+ * DhExchange.
+ * 
+ * @author Christian Plattner, plattner@trilead.com
+ * @version $Id: DhExchange.java,v 1.2 2008/04/01 12:38:09 cplattne Exp $
  */
-public class DhExchange extends GenericDhExchange {
+public class DhExchange
+{
+	private static final Logger log = Logger.getLogger(DhExchange.class);
 
 	/* Given by the standard */
 
-	private static final BigInteger P1 = new BigInteger(
-			  "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1"
-			+ "29024E088A67CC74020BBEA63B139B22514A08798E3404DD"
-			+ "EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245"
-			+ "E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED"
-			+ "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381"
-			+ "FFFFFFFFFFFFFFFF", 16);
+	static final BigInteger p1, p14;
+	static final BigInteger g;
 
-	private static final BigInteger P14 = new BigInteger(
-			  "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1"
-			+ "29024E088A67CC74020BBEA63B139B22514A08798E3404DD"
-			+ "EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245"
-			+ "E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED"
-			+ "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D"
-			+ "C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F"
-			+ "83655D23DCA3AD961C62F356208552BB9ED529077096966D"
-			+ "670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B"
-			+ "E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9"
-			+ "DE2BCBF6955817183995497CEA956AE515D2261898FA0510"
-			+ "15728E5A8AACAA68FFFFFFFFFFFFFFFF", 16);
-
-	private static final BigInteger G = BigInteger.valueOf(2);
+	BigInteger p;
 
 	/* Client public and private */
 
-	private DHPrivateKey clientPrivate;
-	private DHPublicKey clientPublic;
+	BigInteger e;
+	BigInteger x;
 
 	/* Server public */
 
-	private DHPublicKey serverPublic;
+	BigInteger f;
 
-	@Override
-	public void init(String name) throws IOException {
-		final DHParameterSpec spec;
-		if ("diffie-hellman-group1-sha1".equals(name)) {
-			spec = new DHParameterSpec(P1, G);
-		} else if ("diffie-hellman-group14-sha1".equals(name)) {
-			spec = new DHParameterSpec(P14, G);
-		} else {
-			throw new IllegalArgumentException("Unknown DH group " + name);
+	/* Shared secret */
+
+	BigInteger k;
+
+	static
+	{
+		final String p1_string = "17976931348623159077083915679378745319786029604875"
+				+ "60117064444236841971802161585193689478337958649255415021805654859805036464"
+				+ "40548199239100050792877003355816639229553136239076508735759914822574862575"
+				+ "00742530207744771258955095793777842444242661733472762929938766870920560605"
+				+ "0270810842907692932019128194467627007";
+
+		final String p14_string = "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129"
+				+ "024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0"
+				+ "A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB"
+				+ "6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3DC2007CB8A"
+				+ "163BF0598DA48361C55D39A69163FA8FD24CF5F83655D23DCA3AD961C62F356208"
+				+ "552BB9ED529077096966D670C354E4ABC9804F1746C08CA18217C32905E462E36C"
+				+ "E3BE39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9DE2BCBF69558171"
+				+ "83995497CEA956AE515D2261898FA051015728E5A8AACAA68FFFFFFFFFFFFFFFF";
+
+		p1 = new BigInteger(p1_string);
+		p14 = new BigInteger(p14_string, 16);
+		g = new BigInteger("2");
+	}
+
+	public DhExchange()
+	{
+	}
+
+	public void init(int group, SecureRandom rnd)
+	{
+		k = null;
+
+		if (group == 1)
+			p = p1;
+		else if (group == 14)
+			p = p14;
+		else
+			throw new IllegalArgumentException("Unknown DH group " + group);
+
+		x = new BigInteger(p.bitLength() - 1, rnd);
+
+		e = g.modPow(x, p);
+	}
+
+	/**
+	 * @return Returns the e.
+	 * @throws IllegalStateException
+	 */
+	public BigInteger getE()
+	{
+		if (e == null)
+			throw new IllegalStateException("DhDsaExchange not initialized!");
+
+		return e;
+	}
+
+	/**
+	 * @return Returns the shared secret k.
+	 * @throws IllegalStateException
+	 */
+	public BigInteger getK()
+	{
+		if (k == null)
+			throw new IllegalStateException("Shared secret not yet known, need f first!");
+
+		return k;
+	}
+
+	/**
+	 * @param f
+	 */
+	public void setF(BigInteger f)
+	{
+		if (e == null)
+			throw new IllegalStateException("DhDsaExchange not initialized!");
+
+		BigInteger zero = BigInteger.valueOf(0);
+
+		if (zero.compareTo(f) >= 0 || p.compareTo(f) <= 0)
+			throw new IllegalArgumentException("Invalid f specified!");
+
+		this.f = f;
+		this.k = f.modPow(x, p);
+	}
+
+	public byte[] calculateH(byte[] clientversion, byte[] serverversion, byte[] clientKexPayload,
+			byte[] serverKexPayload, byte[] hostKey) throws UnsupportedEncodingException
+	{
+		HashForSSH2Types hash = new HashForSSH2Types("SHA1");
+
+		if (log.isEnabled())
+		{
+			log.log(90, "Client: '" + new String(clientversion, "ISO-8859-1") + "'");
+			log.log(90, "Server: '" + new String(serverversion, "ISO-8859-1") + "'");
 		}
 
-		try {
-			KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH");
-			kpg.initialize(spec);
-			KeyPair pair = kpg.generateKeyPair();
-			clientPrivate = (DHPrivateKey) pair.getPrivate();
-			clientPublic = (DHPublicKey) pair.getPublic();
-		} catch (NoSuchAlgorithmException e) {
-			throw (IOException) new IOException("No DH keypair generator").initCause(e);
-		} catch (InvalidAlgorithmParameterException e) {
-			throw (IOException) new IOException("Invalid DH parameters").initCause(e);
-		}
-	}
+		hash.updateByteString(clientversion);
+		hash.updateByteString(serverversion);
+		hash.updateByteString(clientKexPayload);
+		hash.updateByteString(serverKexPayload);
+		hash.updateByteString(hostKey);
+		hash.updateBigInt(e);
+		hash.updateBigInt(f);
+		hash.updateBigInt(k);
 
-	@Override
-	public byte[] getE() {
-		if (clientPublic == null)
-			throw new IllegalStateException("DhExchange not initialized!");
-
-		return clientPublic.getY().toByteArray();
-	}
-
-	@Override
-	protected byte[] getServerE() {
-		if (serverPublic == null)
-			throw new IllegalStateException("DhExchange not initialized!");
-
-		return serverPublic.getY().toByteArray();
-	}
-
-	@Override
-	public void setF(byte[] f) throws IOException {
-		if (clientPublic == null)
-			throw new IllegalStateException("DhExchange not initialized!");
-
-		final KeyAgreement ka;
-		try {
-			KeyFactory kf = KeyFactory.getInstance("DH");
-			DHParameterSpec params = clientPublic.getParams();
-			this.serverPublic = (DHPublicKey) kf.generatePublic(new DHPublicKeySpec(
-					new BigInteger(f), params.getP(), params.getG()));
-
-			ka = KeyAgreement.getInstance("DH");
-			ka.init(clientPrivate);
-			ka.doPhase(serverPublic, true);
-		} catch (NoSuchAlgorithmException e) {
-			throw (IOException) new IOException("No DH key agreement method").initCause(e);
-		} catch (InvalidKeyException e) {
-			throw (IOException) new IOException("Invalid DH key").initCause(e);
-		} catch (InvalidKeySpecException e) {
-			throw (IOException) new IOException("Invalid DH key").initCause(e);
-		}
-
-		sharedSecret = new BigInteger(ka.generateSecret());
-	}
-
-	@Override
-	public String getHashAlgo() {
-		return "SHA1";
+		return hash.getDigest();
 	}
 }

--- a/src/com/trilead/ssh2/crypto/dh/DhExchangeNew.java
+++ b/src/com/trilead/ssh2/crypto/dh/DhExchangeNew.java
@@ -1,0 +1,129 @@
+package com.trilead.ssh2.crypto.dh;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+import javax.crypto.KeyAgreement;
+import javax.crypto.interfaces.DHPrivateKey;
+import javax.crypto.interfaces.DHPublicKey;
+import javax.crypto.spec.DHParameterSpec;
+import javax.crypto.spec.DHPublicKeySpec;
+
+/**
+ * @author kenny
+ *
+ */
+public class DhExchangeNew extends GenericDhExchange {
+
+	/* Given by the standard */
+
+	private static final BigInteger P1 = new BigInteger(
+			  "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1"
+			+ "29024E088A67CC74020BBEA63B139B22514A08798E3404DD"
+			+ "EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245"
+			+ "E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED"
+			+ "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381"
+			+ "FFFFFFFFFFFFFFFF", 16);
+
+	private static final BigInteger P14 = new BigInteger(
+			  "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1"
+			+ "29024E088A67CC74020BBEA63B139B22514A08798E3404DD"
+			+ "EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245"
+			+ "E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED"
+			+ "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D"
+			+ "C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F"
+			+ "83655D23DCA3AD961C62F356208552BB9ED529077096966D"
+			+ "670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B"
+			+ "E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9"
+			+ "DE2BCBF6955817183995497CEA956AE515D2261898FA0510"
+			+ "15728E5A8AACAA68FFFFFFFFFFFFFFFF", 16);
+
+	private static final BigInteger G = BigInteger.valueOf(2);
+
+	/* Client public and private */
+
+	private DHPrivateKey clientPrivate;
+	private DHPublicKey clientPublic;
+
+	/* Server public */
+
+	private DHPublicKey serverPublic;
+
+	@Override
+	public void init(String name) throws IOException {
+		final DHParameterSpec spec;
+		if ("diffie-hellman-group1-sha1".equals(name)) {
+			spec = new DHParameterSpec(P1, G);
+		} else if ("diffie-hellman-group14-sha1".equals(name)) {
+			spec = new DHParameterSpec(P14, G);
+		} else {
+			throw new IllegalArgumentException("Unknown DH group " + name);
+		}
+
+		try {
+			KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH");
+			kpg.initialize(spec);
+			KeyPair pair = kpg.generateKeyPair();
+			clientPrivate = (DHPrivateKey) pair.getPrivate();
+			clientPublic = (DHPublicKey) pair.getPublic();
+		} catch (NoSuchAlgorithmException e) {
+			throw (IOException) new IOException("No DH keypair generator").initCause(e);
+		} catch (InvalidAlgorithmParameterException e) {
+			throw (IOException) new IOException("Invalid DH parameters").initCause(e);
+		}
+	}
+
+	@Override
+	public byte[] getE() {
+		if (clientPublic == null)
+			throw new IllegalStateException("DhExchange not initialized!");
+
+		return clientPublic.getY().toByteArray();
+	}
+
+	@Override
+	protected byte[] getServerE() {
+		if (serverPublic == null)
+			throw new IllegalStateException("DhExchange not initialized!");
+
+		return serverPublic.getY().toByteArray();
+	}
+
+	@Override
+	public void setF(byte[] f) throws IOException {
+		if (clientPublic == null)
+			throw new IllegalStateException("DhExchange not initialized!");
+
+		final KeyAgreement ka;
+		try {
+			KeyFactory kf = KeyFactory.getInstance("DH");
+			DHParameterSpec params = clientPublic.getParams();
+			this.serverPublic = (DHPublicKey) kf.generatePublic(new DHPublicKeySpec(
+					new BigInteger(f), params.getP(), params.getG()));
+
+			ka = KeyAgreement.getInstance("DH");
+			ka.init(clientPrivate);
+			ka.doPhase(serverPublic, true);
+		} catch (NoSuchAlgorithmException e) {
+			throw (IOException) new IOException("No DH key agreement method").initCause(e);
+		} catch (InvalidKeyException e) {
+			throw (IOException) new IOException("Invalid DH key").initCause(e);
+		} catch (InvalidKeySpecException e) {
+			throw (IOException) new IOException("Invalid DH key").initCause(e);
+		}
+
+		sharedSecret = new BigInteger(ka.generateSecret());
+	}
+
+	@Override
+	public String getHashAlgo() {
+		return "SHA1";
+	}
+}

--- a/src/com/trilead/ssh2/crypto/dh/DhGroupExchange.java
+++ b/src/com/trilead/ssh2/crypto/dh/DhGroupExchange.java
@@ -4,7 +4,7 @@ import java.math.BigInteger;
 import java.security.SecureRandom;
 
 import com.trilead.ssh2.DHGexParameters;
-import com.trilead.ssh2.crypto.digest.HashForSSH2Types;
+import com.trilead.ssh2.crypto.digest.HashForSSH2TypesNew;
 
 
 /**
@@ -89,7 +89,7 @@ public class DhGroupExchange
 	public byte[] calculateH(byte[] clientversion, byte[] serverversion, byte[] clientKexPayload,
  			byte[] serverKexPayload, byte[] hostKey, DHGexParameters para)
 	{
-		HashForSSH2Types hash = new HashForSSH2Types("SHA1");
+		HashForSSH2TypesNew hash = new HashForSSH2TypesNew("SHA1");
 
 		hash.updateByteString(clientversion);
 		hash.updateByteString(serverversion);
@@ -113,7 +113,7 @@ public class DhGroupExchange
 	public byte[] calculateH(String hashAlgo, byte[] clientversion, byte[] serverversion,
 			byte[] clientKexPayload, byte[] serverKexPayload, byte[] hostKey, DHGexParameters para)
 	{
-		HashForSSH2Types hash = new HashForSSH2Types(hashAlgo);
+		HashForSSH2TypesNew hash = new HashForSSH2TypesNew(hashAlgo);
 
 		hash.updateByteString(clientversion);
 		hash.updateByteString(serverversion);

--- a/src/com/trilead/ssh2/crypto/dh/DhGroupExchange.java
+++ b/src/com/trilead/ssh2/crypto/dh/DhGroupExchange.java
@@ -89,25 +89,7 @@ public class DhGroupExchange
 	public byte[] calculateH(byte[] clientversion, byte[] serverversion, byte[] clientKexPayload,
  			byte[] serverKexPayload, byte[] hostKey, DHGexParameters para)
 	{
-		HashForSSH2TypesNew hash = new HashForSSH2TypesNew("SHA1");
-
-		hash.updateByteString(clientversion);
-		hash.updateByteString(serverversion);
-		hash.updateByteString(clientKexPayload);
-		hash.updateByteString(serverKexPayload);
-		hash.updateByteString(hostKey);
-		if (para.getMin_group_len() > 0)
-			hash.updateUINT32(para.getMin_group_len());
-		hash.updateUINT32(para.getPref_group_len());
-		if (para.getMax_group_len() > 0)
-			hash.updateUINT32(para.getMax_group_len());
-		hash.updateBigInt(p);
-		hash.updateBigInt(g);
-		hash.updateBigInt(e);
-		hash.updateBigInt(f);
-		hash.updateBigInt(k);
-
-		return hash.getDigest();
+		return calculateH("SHA1", clientversion, serverversion, clientKexPayload, serverKexPayload, hostKey, para);
 	}
 
 	public byte[] calculateH(String hashAlgo, byte[] clientversion, byte[] serverversion,

--- a/src/com/trilead/ssh2/crypto/dh/GenericDhExchange.java
+++ b/src/com/trilead/ssh2/crypto/dh/GenericDhExchange.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 
-import com.trilead.ssh2.crypto.digest.HashForSSH2Types;
+import com.trilead.ssh2.crypto.digest.HashForSSH2TypesNew;
 import com.trilead.ssh2.log.Logger;
 
 
@@ -27,7 +27,7 @@ public abstract class GenericDhExchange
 	}
 
 	public static GenericDhExchange getInstance(String algo) {
-		return new DhExchange();
+		return new DhExchangeNew();
 	}
 
 	public abstract void init(String name) throws IOException;
@@ -64,7 +64,7 @@ public abstract class GenericDhExchange
 	public byte[] calculateH(byte[] clientversion, byte[] serverversion, byte[] clientKexPayload,
 			byte[] serverKexPayload, byte[] hostKey) throws UnsupportedEncodingException
 	{
-		HashForSSH2Types hash = new HashForSSH2Types(getHashAlgo());
+		HashForSSH2TypesNew hash = new HashForSSH2TypesNew(getHashAlgo());
 
 		if (log.isEnabled())
 		{

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2Types.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2Types.java
@@ -8,8 +8,9 @@ import java.math.BigInteger;
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: HashForSSH2Types.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
+ *
+ * @deprecated use HashForSSH2TypesNew instead
  */
-// @deprecated use HashForSSH2TypesNew instead
 public class HashForSSH2Types
 {
 	Digest md;

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2Types.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2Types.java
@@ -1,27 +1,37 @@
+
 package com.trilead.ssh2.crypto.digest;
 
 import java.math.BigInteger;
-import java.security.DigestException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * HashForSSH2Types.
- *
+ * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: HashForSSH2Types.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
+ *
+ * @deprecated use HashForSSH2TypesNew instead
  */
-public class HashForSSH2Types
+public class HashForSSH2Types instead
 {
-	MessageDigest md;
+	Digest md;
+
+	public HashForSSH2Types(Digest md)
+	{
+		this.md = md;
+	}
 
 	public HashForSSH2Types(String type)
 	{
-		try {
-			md = MessageDigest.getInstance(type);
-		} catch (NoSuchAlgorithmException e) {
-			throw new RuntimeException("Unsupported algorithm " + type);
+		if (type.equals("SHA1"))
+		{
+			md = new SHA1();
 		}
+		else if (type.equals("MD5"))
+		{
+			md = new MD5();
+		}
+		else
+			throw new IllegalArgumentException("Unknown algorithm " + type);
 	}
 
 	public void updateByte(byte b)
@@ -80,11 +90,6 @@ public class HashForSSH2Types
 
 	public void getDigest(byte[] out, int off)
 	{
-		try {
-			md.digest(out, off, out.length - off);
-		} catch (DigestException e) {
-			// TODO is this right?!
-			throw new RuntimeException("Unable to digest", e);
-		}
+		md.digest(out, off);
 	}
 }

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2Types.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2Types.java
@@ -8,9 +8,8 @@ import java.math.BigInteger;
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: HashForSSH2Types.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
- *
- * @deprecated use HashForSSH2TypesNew instead
  */
+// @deprecated use HashForSSH2TypesNew instead
 public class HashForSSH2Types instead
 {
 	Digest md;

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2Types.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2Types.java
@@ -10,7 +10,7 @@ import java.math.BigInteger;
  * @version $Id: HashForSSH2Types.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
  */
 // @deprecated use HashForSSH2TypesNew instead
-public class HashForSSH2Types instead
+public class HashForSSH2Types
 {
 	Digest md;
 

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
@@ -64,7 +64,7 @@ public class HashForSSH2TypesNew
 		return md.getDigestLength();
 	}
 
-	public byte[] getDigest()
+	public byte[] getDigest() throws IOException
 	{
 		byte[] tmp = new byte[md.getDigestLength()];
 		getDigest(tmp);

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
@@ -4,6 +4,7 @@ import java.math.BigInteger;
 import java.security.DigestException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.io.IOException;
 
 /**
  * HashForSSH2TypesNew.

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
@@ -76,7 +76,7 @@ public class HashForSSH2TypesNew
 		getDigest(out, 0);
 	}
 
-	public void getDigest(byte[] out, int off)
+	public void getDigest(byte[] out, int off) throws IOException
 	{
 		try {
 			md.digest(out, off, out.length - off);

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
@@ -15,7 +15,7 @@ public class HashForSSH2TypesNew
 {
 	MessageDigest md;
 
-	public HashForSSH2Types(String type)
+	public HashForSSH2TypesNew(String type)
 	{
 		try {
 			md = MessageDigest.getInstance(type);

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
@@ -7,13 +7,10 @@ import java.security.NoSuchAlgorithmException;
 
 /**
  * HashForSSH2TypesNew.
- * 
- * @author Christian Plattner, plattner@trilead.com
- * @version $Id: HashForSSH2Types.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
  */
 public class HashForSSH2TypesNew
 {
-	MessageDigest md;
+	private MessageDigest md;
 
 	public HashForSSH2TypesNew(String type)
 	{

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
@@ -7,6 +7,9 @@ import java.security.NoSuchAlgorithmException;
 
 /**
  * HashForSSH2TypesNew.
+ * 
+ * @author Christian Plattner, plattner@trilead.com
+ * @version $Id: HashForSSH2Types.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
  */
 public class HashForSSH2TypesNew
 {

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
@@ -80,8 +80,7 @@ public class HashForSSH2TypesNew
 		try {
 			md.digest(out, off, out.length - off);
 		} catch (DigestException e) {
-			// TODO is this right?!
-			throw new RuntimeException("Unable to digest", e);
+			throw new IOExceptions("Unable to digest", e);
 		}
 	}
 }

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
@@ -4,7 +4,6 @@ import java.math.BigInteger;
 import java.security.DigestException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.io.IOException;
 
 /**
  * HashForSSH2TypesNew.
@@ -64,24 +63,24 @@ public class HashForSSH2TypesNew
 		return md.getDigestLength();
 	}
 
-	public byte[] getDigest() throws IOException
+	public byte[] getDigest()
 	{
 		byte[] tmp = new byte[md.getDigestLength()];
 		getDigest(tmp);
 		return tmp;
 	}
 
-	public void getDigest(byte[] out) throws IOException
+	public void getDigest(byte[] out)
 	{
 		getDigest(out, 0);
 	}
 
-	public void getDigest(byte[] out, int off) throws IOException
+	public void getDigest(byte[] out, int off)
 	{
 		try {
 			md.digest(out, off, out.length - off);
 		} catch (DigestException e) {
-			throw new IOException("Unable to digest", e);
+			throw new RuntimeException("Unable to digest", e);
 		}
 	}
 }

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
@@ -4,7 +4,7 @@ import java.math.BigInteger;
 import java.security.DigestException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.io.IOException;
+import java.io.IOExceptions;
 
 /**
  * HashForSSH2TypesNew.

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
@@ -71,7 +71,7 @@ public class HashForSSH2TypesNew
 		return tmp;
 	}
 
-	public void getDigest(byte[] out)
+	public void getDigest(byte[] out) throws IOException
 	{
 		getDigest(out, 0);
 	}

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2TypesNew.java
@@ -4,7 +4,7 @@ import java.math.BigInteger;
 import java.security.DigestException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.io.IOExceptions;
+import java.io.IOException;
 
 /**
  * HashForSSH2TypesNew.
@@ -81,7 +81,7 @@ public class HashForSSH2TypesNew
 		try {
 			md.digest(out, off, out.length - off);
 		} catch (DigestException e) {
-			throw new IOExceptions("Unable to digest", e);
+			throw new IOException("Unable to digest", e);
 		}
 	}
 }

--- a/src/com/trilead/ssh2/crypto/digest/MACNew.java
+++ b/src/com/trilead/ssh2/crypto/digest/MACNew.java
@@ -1,0 +1,149 @@
+package com.trilead.ssh2.crypto.digest;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Mac;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * MACNew.
+ * 
+ * @author Christian Plattner, plattner@trilead.com
+ * @version $Id: MACNew.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
+ */
+public final class MACNew
+{
+	private enum Hmac
+	{
+		HMAC_MD5("hmac-md5", "HmacMD5", 16), // http://tools.ietf.org/html/rfc4253
+		HMAC_MD5_96("hmac-md5-96", "HmacMD5", 16), // http://tools.ietf.org/html/rfc4253
+		HMAC_SHA1("hmac-sha1", "HmacSHA1", 20), // http://tools.ietf.org/html/rfc4253
+		HMAC_SHA1_96("hmac-sha1-96", "HmacSHA1", 20), // http://tools.ietf.org/html/rfc4253
+		HMAC_SHA2_256("hmac-sha2-256", "HmacSHA256", 32), // http://tools.ietf.org/html/rfc6668
+		HMAC_SHA2_512("hmac-sha2-512", "HmacSHA512", 64); // http://tools.ietf.org/html/rfc6668
+
+		private String type;
+		private String algorithm;
+		private int length;
+
+		Hmac(String type, String algorithm, int length) 
+		{
+			this.type = type;
+			this.algorithm = algorithm;
+			this.length = length;
+		}
+
+		private static Hmac getHmac(String type) 
+		{
+			try 
+			{
+				return Hmac.valueOf(type.replaceAll("-", "_").toUpperCase());
+			} 
+			catch (Exception e) 
+			{
+				throw new IllegalArgumentException("Unkown algorithm " + type);
+			}
+		}
+	}
+
+	private static final String[] PRIORITIZED_MAC_LIST = { Hmac.HMAC_SHA2_256.type, Hmac.HMAC_SHA2_512.type,
+			Hmac.HMAC_SHA1_96.type, Hmac.HMAC_SHA1.type, Hmac.HMAC_MD5_96.type, Hmac.HMAC_MD5.type };
+
+	Mac mac;
+	int outSize;
+	int macSize;
+	byte[] buffer;
+
+	public final static String[] getMacList() 
+	{
+		return PRIORITIZED_MAC_LIST;
+	}
+
+	public final static void checkMacList(String[] macs) 
+	{
+		for (int i = 0; i < macs.length; i++)
+			getKeyLen(macs[i]);
+	}
+
+	public final static int getKeyLen(String type) 
+	{
+		return Hmac.getHmac(type).length;
+	}
+
+	public MACNew(String type, byte[] key) 
+	{
+		try 
+		{
+			mac = Mac.getInstance(Hmac.getHmac(type).algorithm);
+		} 
+		catch (NoSuchAlgorithmException e) 
+		{
+			throw new IllegalArgumentException("Unknown algorithm " + type, e);
+		}
+
+		macSize = mac.getMacLength();
+		if (type.endsWith("-256")) {
+			outSize = 32;
+			buffer = new byte[macSize];
+		} else if (type.endsWith("-512")) {
+			outSize = 64;
+			buffer = new byte[macSize];
+		} else if (type.endsWith("-96")) {
+			outSize = 12;
+			buffer = new byte[macSize];
+		} else {
+			outSize = macSize;
+			buffer = null;
+		}
+
+		try 
+		{
+			mac.init(new SecretKeySpec(key, type));
+		} 
+		catch (InvalidKeyException e) 
+		{
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	public final void initMac(int seq) 
+	{
+		mac.reset();
+		mac.update((byte) (seq >> 24));
+		mac.update((byte) (seq >> 16));
+		mac.update((byte) (seq >> 8));
+		mac.update((byte) (seq));
+	}
+
+	public final void update(byte[] packetdata, int off, int len)
+	{
+		mac.update(packetdata, off, len);
+	}
+
+	public final void getMac(byte[] out, int off) 
+	{
+		try
+		{
+			if (buffer != null) 
+			{
+				mac.doFinal(buffer, 0);
+				System.arraycopy(buffer, 0, out, off, out.length - off);
+			} 
+			else 
+			{
+				mac.doFinal(out, off);
+			}
+		} 
+		catch (ShortBufferException e) 
+		{
+			throw new IllegalStateException(e);
+		}
+	}
+
+	public final int size() 
+	{
+		return outSize;
+	}
+}

--- a/src/com/trilead/ssh2/packets/PacketKexDHInit.java
+++ b/src/com/trilead/ssh2/packets/PacketKexDHInit.java
@@ -1,5 +1,7 @@
 package com.trilead.ssh2.packets;
 
+import java.math.BigInteger;
+
 /**
  * PacketKexDHInit.
  * 
@@ -10,11 +12,11 @@ public class PacketKexDHInit
 {
 	byte[] payload;
 
-	byte[] publicKey;
+	BigInteger e;
 
-	public PacketKexDHInit(byte[] publicKey)
+	public PacketKexDHInit(BigInteger e)
 	{
-		this.publicKey = publicKey;
+		this.e = e;
 	}
 
 	public byte[] getPayload()
@@ -23,7 +25,7 @@ public class PacketKexDHInit
 		{
 			TypesWriter tw = new TypesWriter();
 			tw.writeByte(Packets.SSH_MSG_KEXDH_INIT);
-			tw.writeString(publicKey, 0, publicKey.length);
+			tw.writeMPInt(e);
 			payload = tw.getBytes();
 		}
 		return payload;

--- a/src/com/trilead/ssh2/packets/PacketKexDHInit.java
+++ b/src/com/trilead/ssh2/packets/PacketKexDHInit.java
@@ -7,6 +7,8 @@ import java.math.BigInteger;
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: PacketKexDHInit.java,v 1.1 2007/10/15 12:49:55 cplattne Exp $
+ *
+ * Deprecated use PacketKexDHInitNew.
  */
 public class PacketKexDHInit
 {

--- a/src/com/trilead/ssh2/packets/PacketKexDHInitNew.java
+++ b/src/com/trilead/ssh2/packets/PacketKexDHInitNew.java
@@ -2,9 +2,6 @@ package com.trilead.ssh2.packets;
 
 /**
  * PacketKexDHInitNew.
- * 
- * @author Christian Plattner, plattner@trilead.com
- * @version $Id: PacketKexDHInit.java,v 1.1 2007/10/15 12:49:55 cplattne Exp $
  */
 public class PacketKexDHInitNew
 {

--- a/src/com/trilead/ssh2/packets/PacketKexDHInitNew.java
+++ b/src/com/trilead/ssh2/packets/PacketKexDHInitNew.java
@@ -1,0 +1,31 @@
+package com.trilead.ssh2.packets;
+
+/**
+ * PacketKexDHInitNew.
+ * 
+ * @author Christian Plattner, plattner@trilead.com
+ * @version $Id: PacketKexDHInit.java,v 1.1 2007/10/15 12:49:55 cplattne Exp $
+ */
+public class PacketKexDHInitNew
+{
+	byte[] payload;
+
+	byte[] publicKey;
+
+	public PacketKexDHInitNew(byte[] publicKey)
+	{
+		this.publicKey = publicKey;
+	}
+
+	public byte[] getPayload()
+	{
+		if (payload == null)
+		{
+			TypesWriter tw = new TypesWriter();
+			tw.writeByte(Packets.SSH_MSG_KEXDH_INIT);
+			tw.writeString(publicKey, 0, publicKey.length);
+			payload = tw.getBytes();
+		}
+		return payload;
+	}
+}

--- a/src/com/trilead/ssh2/packets/PacketKexDHReply.java
+++ b/src/com/trilead/ssh2/packets/PacketKexDHReply.java
@@ -2,18 +2,22 @@ package com.trilead.ssh2.packets;
 
 import java.io.IOException;
 
+import java.math.BigInteger;
+
 /**
  * PacketKexDHReply.
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: PacketKexDHReply.java,v 1.1 2007/10/15 12:49:55 cplattne Exp $
+ *
+ * @Deprecated use PacketKexDHReplyNew.
  */
 public class PacketKexDHReply
 {
 	byte[] payload;
 
 	byte[] hostKey;
-	byte[] publicKey;
+	BigInteger f;
 	byte[] signature;
 	
 	public PacketKexDHReply(byte payload[], int off, int len) throws IOException
@@ -30,15 +34,15 @@ public class PacketKexDHReply
 					+ packet_type + ")");
 
 		hostKey = tr.readByteString();
-		publicKey = tr.readByteString();
+		f = tr.readMPINT();
 		signature = tr.readByteString();
 
 		if (tr.remain() != 0) throw new IOException("PADDING IN SSH_MSG_KEXDH_REPLY!");
 	}
 
-	public byte[] getF()
+	public BigInteger getF()
 	{
-		return publicKey;
+		return f;
 	}
 	
 	public byte[] getHostKey()

--- a/src/com/trilead/ssh2/packets/PacketKexDHReplyNew.java
+++ b/src/com/trilead/ssh2/packets/PacketKexDHReplyNew.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 /**
  * PacketKexDHReply.
  */
-public class PacketKexDHReply
+public class PacketKexDHReplyNew
 {
 	byte[] payload;
 
@@ -13,7 +13,7 @@ public class PacketKexDHReply
 	byte[] publicKey;
 	byte[] signature;
 	
-	public PacketKexDHReply(byte payload[], int off, int len) throws IOException
+	public PacketKexDHReplyNew(byte payload[], int off, int len) throws IOException
 	{
 		this.payload = new byte[len];
 		System.arraycopy(payload, off, this.payload, 0, len);

--- a/src/com/trilead/ssh2/packets/PacketKexDHReplyNew.java
+++ b/src/com/trilead/ssh2/packets/PacketKexDHReplyNew.java
@@ -1,0 +1,50 @@
+package com.trilead.ssh2.packets;
+
+import java.io.IOException;
+
+/**
+ * PacketKexDHReply.
+ */
+public class PacketKexDHReply
+{
+	byte[] payload;
+
+	byte[] hostKey;
+	byte[] publicKey;
+	byte[] signature;
+	
+	public PacketKexDHReply(byte payload[], int off, int len) throws IOException
+	{
+		this.payload = new byte[len];
+		System.arraycopy(payload, off, this.payload, 0, len);
+
+		TypesReader tr = new TypesReader(payload, off, len);
+
+		int packet_type = tr.readByte();
+
+		if (packet_type != Packets.SSH_MSG_KEXDH_REPLY)
+			throw new IOException("This is not a SSH_MSG_KEXDH_REPLY! ("
+					+ packet_type + ")");
+
+		hostKey = tr.readByteString();
+		publicKey = tr.readByteString();
+		signature = tr.readByteString();
+
+		if (tr.remain() != 0) throw new IOException("PADDING IN SSH_MSG_KEXDH_REPLY!");
+	}
+
+	public byte[] getF()
+	{
+		return publicKey;
+	}
+	
+	public byte[] getHostKey()
+	{
+		return hostKey;
+	}
+
+	public byte[] getSignature()
+	{
+		return signature;
+	}
+}

--- a/src/com/trilead/ssh2/packets/PacketKexInit.java
+++ b/src/com/trilead/ssh2/packets/PacketKexInit.java
@@ -39,7 +39,7 @@ public class PacketKexInit
 		kp.reserved_field1 = 0;
 	}
 
-	public PacketKeyInit(CryptoWishList cwl) {
+	public PacketKexInit(CryptoWishList cwl) {
 	   this(cwl, new SecureRandom());
 	}
 

--- a/src/com/trilead/ssh2/packets/PacketKexInit.java
+++ b/src/com/trilead/ssh2/packets/PacketKexInit.java
@@ -39,8 +39,8 @@ public class PacketKexInit
 		kp.reserved_field1 = 0;
 	}
 
-	public PacketKeyInit(CryptoWishList cw1) {
-	   this(cw1, new SecureRandom());
+	public PacketKeyInit(CryptoWishList cwl) {
+	   this(cwl, new SecureRandom());
 	}
 
 	public PacketKexInit(byte payload[], int off, int len) throws IOException

--- a/src/com/trilead/ssh2/packets/PacketKexInit.java
+++ b/src/com/trilead/ssh2/packets/PacketKexInit.java
@@ -20,7 +20,7 @@ public class PacketKexInit
 
 	KexParameters kp = new KexParameters();
 
-	public PacketKexInit(CryptoWishList cwl)
+	public PacketKexInit(CryptoWishList cwl, SecureRandom rnd)
 	{
 		kp.cookie = new byte[16];
 		new SecureRandom().nextBytes(kp.cookie);
@@ -37,6 +37,10 @@ public class PacketKexInit
 		kp.languages_server_to_client = new String[] {};
 		kp.first_kex_packet_follows = false;
 		kp.reserved_field1 = 0;
+	}
+
+	public PacketKeyInit(CryptoWishList cw1) {
+	   this(cw1, new SecureRandom());
 	}
 
 	public PacketKexInit(byte payload[], int off, int len) throws IOException

--- a/src/com/trilead/ssh2/packets/PacketKexInit.java
+++ b/src/com/trilead/ssh2/packets/PacketKexInit.java
@@ -23,7 +23,7 @@ public class PacketKexInit
 	public PacketKexInit(CryptoWishList cwl, SecureRandom rnd)
 	{
 		kp.cookie = new byte[16];
-		new SecureRandom().nextBytes(kp.cookie);
+		rnd.nextBytes(kp.cookie);
 
 		kp.kex_algorithms = cwl.kexAlgorithms;
 		kp.server_host_key_algorithms = cwl.serverHostKeyAlgorithms;

--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -44,7 +44,7 @@ public class KexManager implements MessageHandler
 {
 	private static final Logger log = Logger.getLogger(KexManager.class);
 
-	KexState kxs;
+	KexStateNew kxs;
 	int kexCount = 0;
 	KeyMaterial km;
 	byte[] sessionId;
@@ -240,7 +240,7 @@ public class KexManager implements MessageHandler
 
 		if (kxs == null)
 		{
-			kxs = new KexState();
+			kxs = new KexStateNew();
 
 			kxs.dhgexParameters = nextKEXdhgexParameters;
 			PacketKexInit kp = new PacketKexInit(nextKEXcryptoWishList);
@@ -392,7 +392,7 @@ public class KexManager implements MessageHandler
 				 * Ah, OK, peer wants to do KEX. Let's be nice and play
 				 * together.
 				 */
-				kxs = new KexState();
+				kxs = new KexStateNew();
 				kxs.dhgexParameters = nextKEXdhgexParameters;
 				kip = new PacketKexInit(nextKEXcryptoWishList);
 				kxs.localKEX = kip;

--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -57,7 +57,7 @@ public class KexManager implements MessageHandler
 
 	boolean ignore_next_kex_packet = false;
 
-	final TransportManager tm;
+	final TransportManagerNew tm;
 
 	CryptoWishList nextKEXcryptoWishList;
 	DHGexParameters nextKEXdhgexParameters;
@@ -67,7 +67,7 @@ public class KexManager implements MessageHandler
 	final int port;
 	final SecureRandom rnd;
 
-	public KexManager(TransportManager tm, ClientServerHello csh, CryptoWishList initialCwl, String hostname, int port,
+	public KexManager(TransportManagerNew tm, ClientServerHello csh, CryptoWishList initialCwl, String hostname, int port,
 			ServerHostKeyVerifier keyVerifier, SecureRandom rnd)
 	{
 		this.tm = tm;

--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -14,7 +14,7 @@ import com.trilead.ssh2.crypto.cipher.BlockCipher;
 import com.trilead.ssh2.crypto.cipher.BlockCipherFactory;
 import com.trilead.ssh2.crypto.dh.DhGroupExchange;
 import com.trilead.ssh2.crypto.dh.GenericDhExchange;
-import com.trilead.ssh2.crypto.digest.MAC;
+import com.trilead.ssh2.crypto.digest.MACNew;
 import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.PacketKexDHInitNew;
 import com.trilead.ssh2.packets.PacketKexDHReply;
@@ -253,11 +253,11 @@ public class KexManager implements MessageHandler
 	{
 		try
 		{
-			int mac_cs_key_len = MAC.getKeyLen(kxs.np.mac_algo_client_to_server);
+			int mac_cs_key_len = MACNew.getKeyLen(kxs.np.mac_algo_client_to_server);
 			int enc_cs_key_len = BlockCipherFactory.getKeySize(kxs.np.enc_algo_client_to_server);
 			int enc_cs_block_len = BlockCipherFactory.getBlockSize(kxs.np.enc_algo_client_to_server);
 
-			int mac_sc_key_len = MAC.getKeyLen(kxs.np.mac_algo_server_to_client);
+			int mac_sc_key_len = MACNew.getKeyLen(kxs.np.mac_algo_server_to_client);
 			int enc_sc_key_len = BlockCipherFactory.getKeySize(kxs.np.enc_algo_server_to_client);
 			int enc_sc_block_len = BlockCipherFactory.getBlockSize(kxs.np.enc_algo_server_to_client);
 
@@ -284,14 +284,14 @@ public class KexManager implements MessageHandler
 		tm.sendKexMessage(ign.getPayload());
 
 		BlockCipher cbc;
-		MAC mac;
+		MACNew mac;
 
 		try
 		{
 			cbc = BlockCipherFactory.createCipher(kxs.np.enc_algo_client_to_server, true, km.enc_key_client_to_server,
 					km.initial_iv_client_to_server);
 
-			mac = new MAC(kxs.np.mac_algo_client_to_server, km.integrity_key_client_to_server);
+			mac = new MACNew(kxs.np.mac_algo_client_to_server, km.integrity_key_client_to_server);
 
 		}
 		catch (IllegalArgumentException e1)
@@ -462,14 +462,14 @@ public class KexManager implements MessageHandler
 				throw new IOException("Peer sent SSH_MSG_NEWKEYS, but I have no key material ready!");
 
 			BlockCipher cbc;
-			MAC mac;
+			MACNew mac;
 
 			try
 			{
 				cbc = BlockCipherFactory.createCipher(kxs.np.enc_algo_server_to_client, false,
 						km.enc_key_server_to_client, km.initial_iv_server_to_client);
 
-				mac = new MAC(kxs.np.mac_algo_server_to_client, km.integrity_key_server_to_client);
+				mac = new MACNew(kxs.np.mac_algo_server_to_client, km.integrity_key_server_to_client);
 
 			}
 			catch (IllegalArgumentException e1)

--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -16,7 +16,7 @@ import com.trilead.ssh2.crypto.dh.DhGroupExchange;
 import com.trilead.ssh2.crypto.dh.GenericDhExchange;
 import com.trilead.ssh2.crypto.digest.MAC;
 import com.trilead.ssh2.log.Logger;
-import com.trilead.ssh2.packets.PacketKexDHInit;
+import com.trilead.ssh2.packets.PacketKexDHInitNew;
 import com.trilead.ssh2.packets.PacketKexDHReply;
 import com.trilead.ssh2.packets.PacketKexDhGexGroup;
 import com.trilead.ssh2.packets.PacketKexDhGexInit;
@@ -447,7 +447,7 @@ public class KexManager implements MessageHandler
 				kxs.dhx.init(kxs.np.kex_algo);
 				kxs.hashAlgo = kxs.dhx.getHashAlgo();
 
-				PacketKexDHInit kp = new PacketKexDHInit(kxs.dhx.getE());
+				PacketKexDHInitNew kp = new PacketKexDHInitNew(kxs.dhx.getE());
 				tm.sendKexMessage(kp.getPayload());
 				kxs.state = 1;
 				return;

--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -39,6 +39,8 @@ import com.trilead.ssh2.signature.RSASignature;
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: KexManager.java,v 1.1 2007/10/15 12:49:56 cplattne Exp $
+ *
+ * Deprecated use KexManagerNew.
  */
 public class KexManager implements MessageHandler
 {

--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -17,7 +17,7 @@ import com.trilead.ssh2.crypto.dh.GenericDhExchange;
 import com.trilead.ssh2.crypto.digest.MACNew;
 import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.PacketKexDHInitNew;
-import com.trilead.ssh2.packets.PacketKexDHReply;
+import com.trilead.ssh2.packets.PacketKexDHReplyNew;
 import com.trilead.ssh2.packets.PacketKexDhGexGroup;
 import com.trilead.ssh2.packets.PacketKexDhGexInit;
 import com.trilead.ssh2.packets.PacketKexDhGexReply;
@@ -578,7 +578,7 @@ public class KexManager implements MessageHandler
 			if (kxs.state == 1)
 			{
 
-				PacketKexDHReply dhr = new PacketKexDHReply(msg, 0, msglen);
+				PacketKexDHReplyNew dhr = new PacketKexDHReplyNew(msg, 0, msglen);
 
 				kxs.hostkey = dhr.getHostKey();
 

--- a/src/com/trilead/ssh2/transport/KexManagerNew.java
+++ b/src/com/trilead/ssh2/transport/KexManagerNew.java
@@ -1,0 +1,634 @@
+
+package com.trilead.ssh2.transport;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.security.SecureRandom;
+
+import com.trilead.ssh2.ConnectionInfo;
+import com.trilead.ssh2.DHGexParameters;
+import com.trilead.ssh2.ServerHostKeyVerifier;
+import com.trilead.ssh2.crypto.CryptoWishList;
+import com.trilead.ssh2.crypto.KeyMaterial;
+import com.trilead.ssh2.crypto.cipher.BlockCipher;
+import com.trilead.ssh2.crypto.cipher.BlockCipherFactory;
+import com.trilead.ssh2.crypto.dh.DhGroupExchange;
+import com.trilead.ssh2.crypto.dh.GenericDhExchange;
+import com.trilead.ssh2.crypto.digest.MACNew;
+import com.trilead.ssh2.log.Logger;
+import com.trilead.ssh2.packets.PacketKexDHInitNew;
+import com.trilead.ssh2.packets.PacketKexDHReplyNew;
+import com.trilead.ssh2.packets.PacketKexDhGexGroup;
+import com.trilead.ssh2.packets.PacketKexDhGexInit;
+import com.trilead.ssh2.packets.PacketKexDhGexReply;
+import com.trilead.ssh2.packets.PacketKexDhGexRequest;
+import com.trilead.ssh2.packets.PacketKexDhGexRequestOld;
+import com.trilead.ssh2.packets.PacketKexInit;
+import com.trilead.ssh2.packets.PacketNewKeys;
+import com.trilead.ssh2.packets.Packets;
+import com.trilead.ssh2.signature.DSAPublicKey;
+import com.trilead.ssh2.signature.DSASHA1Verify;
+import com.trilead.ssh2.signature.DSASignature;
+import com.trilead.ssh2.signature.RSAPublicKey;
+import com.trilead.ssh2.signature.RSASHA1Verify;
+import com.trilead.ssh2.signature.RSASignature;
+
+
+/**
+ * KexManagerNew.
+ */
+public class KexManagerNew implements MessageHandler
+{
+	private static final Logger log = Logger.getLogger(KexManager.class);
+
+	KexStateNew kxs;
+	int kexCount = 0;
+	KeyMaterial km;
+	byte[] sessionId;
+	ClientServerHello csh;
+
+	final Object accessLock = new Object();
+	ConnectionInfo lastConnInfo = null;
+
+	boolean connectionClosed = false;
+
+	boolean ignore_next_kex_packet = false;
+
+	final TransportManagerNew tm;
+
+	CryptoWishList nextKEXcryptoWishList;
+	DHGexParameters nextKEXdhgexParameters;
+
+	ServerHostKeyVerifier verifier;
+	final String hostname;
+	final int port;
+	final SecureRandom rnd;
+
+	public KexManagerNew(TransportManagerNew tm, ClientServerHello csh, CryptoWishList initialCwl, String hostname, int port,
+			ServerHostKeyVerifier keyVerifier, SecureRandom rnd)
+	{
+		this.tm = tm;
+		this.csh = csh;
+		this.nextKEXcryptoWishList = initialCwl;
+		this.nextKEXdhgexParameters = new DHGexParameters();
+		this.hostname = hostname;
+		this.port = port;
+		this.verifier = keyVerifier;
+		this.rnd = rnd;
+	}
+
+	public ConnectionInfo getOrWaitForConnectionInfo(int minKexCount) throws IOException
+	{
+		synchronized (accessLock)
+		{
+			while (true)
+			{
+				if ((lastConnInfo != null) && (lastConnInfo.keyExchangeCounter >= minKexCount))
+					return lastConnInfo;
+
+				if (connectionClosed)
+					throw (IOException) new IOException("Key exchange was not finished, connection is closed.")
+							.initCause(tm.getReasonClosedCause());
+
+				try
+				{
+					accessLock.wait();
+				}
+				catch (InterruptedException e)
+				{
+                    throw new InterruptedIOException();
+				}
+			}
+		}
+	}
+
+	private String getFirstMatch(String[] client, String[] server) throws NegotiateException
+	{
+		if (client == null || server == null)
+			throw new IllegalArgumentException();
+
+		if (client.length == 0)
+			return null;
+
+		for (int i = 0; i < client.length; i++)
+		{
+			for (int j = 0; j < server.length; j++)
+			{
+				if (client[i].equals(server[j]))
+					return client[i];
+			}
+		}
+		throw new NegotiateException();
+	}
+
+	private boolean compareFirstOfNameList(String[] a, String[] b)
+	{
+		if (a == null || b == null)
+			throw new IllegalArgumentException();
+
+		if ((a.length == 0) && (b.length == 0))
+			return true;
+
+		if ((a.length == 0) || (b.length == 0))
+			return false;
+
+		return (a[0].equals(b[0]));
+	}
+
+	private boolean isGuessOK(KexParameters cpar, KexParameters spar)
+	{
+		if (cpar == null || spar == null)
+			throw new IllegalArgumentException();
+
+		if (compareFirstOfNameList(cpar.kex_algorithms, spar.kex_algorithms) == false)
+		{
+			return false;
+		}
+
+		if (compareFirstOfNameList(cpar.server_host_key_algorithms, spar.server_host_key_algorithms) == false)
+		{
+			return false;
+		}
+
+		/*
+		 * We do NOT check here if the other algorithms can be agreed on, this
+		 * is just a check if kex_algorithms and server_host_key_algorithms were
+		 * guessed right!
+		 */
+
+		return true;
+	}
+
+	private NegotiatedParameters mergeKexParameters(KexParameters client, KexParameters server)
+	{
+		NegotiatedParameters np = new NegotiatedParameters();
+
+		try
+		{
+			np.kex_algo = getFirstMatch(client.kex_algorithms, server.kex_algorithms);
+
+			log.log(30, "kex_algo=" + np.kex_algo);
+
+			np.server_host_key_algo = getFirstMatch(client.server_host_key_algorithms,
+					server.server_host_key_algorithms);
+
+			log.log(30, "server_host_key_algo=" + np.server_host_key_algo);
+
+			np.enc_algo_client_to_server = getFirstMatch(client.encryption_algorithms_client_to_server,
+					server.encryption_algorithms_client_to_server);
+			np.enc_algo_server_to_client = getFirstMatch(client.encryption_algorithms_server_to_client,
+					server.encryption_algorithms_server_to_client);
+
+			log.log(30, "enc_algo_client_to_server=" + np.enc_algo_client_to_server);
+			log.log(30, "enc_algo_server_to_client=" + np.enc_algo_server_to_client);
+
+			np.mac_algo_client_to_server = getFirstMatch(client.mac_algorithms_client_to_server,
+					server.mac_algorithms_client_to_server);
+			np.mac_algo_server_to_client = getFirstMatch(client.mac_algorithms_server_to_client,
+					server.mac_algorithms_server_to_client);
+
+			log.log(30, "mac_algo_client_to_server=" + np.mac_algo_client_to_server);
+			log.log(30, "mac_algo_server_to_client=" + np.mac_algo_server_to_client);
+
+			np.comp_algo_client_to_server = getFirstMatch(client.compression_algorithms_client_to_server,
+					server.compression_algorithms_client_to_server);
+			np.comp_algo_server_to_client = getFirstMatch(client.compression_algorithms_server_to_client,
+					server.compression_algorithms_server_to_client);
+
+			log.log(30, "comp_algo_client_to_server=" + np.comp_algo_client_to_server);
+			log.log(30, "comp_algo_server_to_client=" + np.comp_algo_server_to_client);
+
+		}
+		catch (NegotiateException e)
+		{
+			return null;
+		}
+
+		try
+		{
+			np.lang_client_to_server = getFirstMatch(client.languages_client_to_server,
+					server.languages_client_to_server);
+		}
+		catch (NegotiateException e1)
+		{
+			np.lang_client_to_server = null;
+		}
+
+		try
+		{
+			np.lang_server_to_client = getFirstMatch(client.languages_server_to_client,
+					server.languages_server_to_client);
+		}
+		catch (NegotiateException e2)
+		{
+			np.lang_server_to_client = null;
+		}
+
+		if (isGuessOK(client, server))
+			np.guessOK = true;
+
+		return np;
+	}
+
+	public synchronized void initiateKEX(CryptoWishList cwl, DHGexParameters dhgex) throws IOException
+	{
+		nextKEXcryptoWishList = cwl;
+		nextKEXdhgexParameters = dhgex;
+
+		if (kxs == null)
+		{
+			kxs = new KexStateNew();
+
+			kxs.dhgexParameters = nextKEXdhgexParameters;
+			PacketKexInit kp = new PacketKexInit(nextKEXcryptoWishList);
+			kxs.localKEX = kp;
+			tm.sendKexMessage(kp.getPayload());
+		}
+	}
+
+	private boolean establishKeyMaterial()
+	{
+		try
+		{
+			int mac_cs_key_len = MACNew.getKeyLen(kxs.np.mac_algo_client_to_server);
+			int enc_cs_key_len = BlockCipherFactory.getKeySize(kxs.np.enc_algo_client_to_server);
+			int enc_cs_block_len = BlockCipherFactory.getBlockSize(kxs.np.enc_algo_client_to_server);
+
+			int mac_sc_key_len = MACNew.getKeyLen(kxs.np.mac_algo_server_to_client);
+			int enc_sc_key_len = BlockCipherFactory.getKeySize(kxs.np.enc_algo_server_to_client);
+			int enc_sc_block_len = BlockCipherFactory.getBlockSize(kxs.np.enc_algo_server_to_client);
+
+			km = KeyMaterial.create(kxs.hashAlgo, kxs.H, kxs.K, sessionId, enc_cs_key_len, enc_cs_block_len, mac_cs_key_len,
+					enc_sc_key_len, enc_sc_block_len, mac_sc_key_len);
+		}
+		catch (IllegalArgumentException e)
+		{
+			return false;
+		}
+		return true;
+	}
+
+	private void finishKex() throws IOException
+	{
+		if (sessionId == null)
+			sessionId = kxs.H;
+
+		establishKeyMaterial();
+
+		/* Tell the other side that we start using the new material */
+
+		PacketNewKeys ign = new PacketNewKeys();
+		tm.sendKexMessage(ign.getPayload());
+
+		BlockCipher cbc;
+		MACNew mac;
+
+		try
+		{
+			cbc = BlockCipherFactory.createCipher(kxs.np.enc_algo_client_to_server, true, km.enc_key_client_to_server,
+					km.initial_iv_client_to_server);
+
+			mac = new MACNew(kxs.np.mac_algo_client_to_server, km.integrity_key_client_to_server);
+
+		}
+		catch (IllegalArgumentException e1)
+		{
+			throw new IOException("Fatal error during MAC startup!");
+		}
+
+		tm.changeSendCipher(cbc, mac);
+		tm.kexFinished();
+	}
+
+	public static final String[] getDefaultServerHostkeyAlgorithmList()
+	{
+		return new String[] { "ssh-rsa", "ssh-dss" };
+	}
+
+	public static final void checkServerHostkeyAlgorithmsList(String[] algos)
+	{
+		for (int i = 0; i < algos.length; i++)
+		{
+			if (("ssh-rsa".equals(algos[i]) == false) && ("ssh-dss".equals(algos[i]) == false))
+				throw new IllegalArgumentException("Unknown server host key algorithm '" + algos[i] + "'");
+		}
+	}
+
+	public static final String[] getDefaultKexAlgorithmList()
+	{
+		return new String[] { "diffie-hellman-group-exchange-sha256", "diffie-hellman-group-exchange-sha1",
+				"diffie-hellman-group14-sha1", "diffie-hellman-group1-sha1" };
+	}
+
+	public static final void checkKexAlgorithmList(String[] algos)
+	{
+		for (int i = 0; i < algos.length; i++)
+		{
+			if ("diffie-hellman-group-exchange-sha256".equals(algos[i]))
+				continue;
+
+			if ("diffie-hellman-group-exchange-sha1".equals(algos[i]))
+				continue;
+
+			if ("diffie-hellman-group14-sha1".equals(algos[i]))
+				continue;
+
+			if ("diffie-hellman-group1-sha1".equals(algos[i]))
+				continue;
+
+			throw new IllegalArgumentException("Unknown kex algorithm '" + algos[i] + "'");
+		}
+	}
+
+	private boolean verifySignature(byte[] sig, byte[] hostkey) throws IOException
+	{
+		if (kxs.np.server_host_key_algo.equals("ssh-rsa"))
+		{
+			RSASignature rs = RSASHA1Verify.decodeSSHRSASignature(sig);
+			RSAPublicKey rpk = RSASHA1Verify.decodeSSHRSAPublicKey(hostkey);
+
+			log.log(50, "Verifying ssh-rsa signature");
+
+			return RSASHA1Verify.verifySignature(kxs.H, rs, rpk);
+		}
+
+		if (kxs.np.server_host_key_algo.equals("ssh-dss"))
+		{
+			DSASignature ds = DSASHA1Verify.decodeSSHDSASignature(sig);
+			DSAPublicKey dpk = DSASHA1Verify.decodeSSHDSAPublicKey(hostkey);
+
+			log.log(50, "Verifying ssh-dss signature");
+
+			return DSASHA1Verify.verifySignature(kxs.H, ds, dpk);
+		}
+
+		throw new IOException("Unknown server host key algorithm '" + kxs.np.server_host_key_algo + "'");
+	}
+
+	public synchronized void handleMessage(byte[] msg, int msglen) throws IOException
+	{
+		PacketKexInit kip;
+
+		if ((kxs == null) && (msg[0] != Packets.SSH_MSG_KEXINIT))
+			throw new IOException("Unexpected KEX message (type " + msg[0] + ")");
+
+		if (ignore_next_kex_packet)
+		{
+			ignore_next_kex_packet = false;
+			return;
+		}
+
+		if (msg[0] == Packets.SSH_MSG_KEXINIT)
+		{
+			if ((kxs != null) && (kxs.state != 0))
+				throw new IOException("Unexpected SSH_MSG_KEXINIT message during on-going kex exchange!");
+
+			if (kxs == null)
+			{
+				/*
+				 * Ah, OK, peer wants to do KEX. Let's be nice and play
+				 * together.
+				 */
+				kxs = new KexStateNew();
+				kxs.dhgexParameters = nextKEXdhgexParameters;
+				kip = new PacketKexInit(nextKEXcryptoWishList);
+				kxs.localKEX = kip;
+				tm.sendKexMessage(kip.getPayload());
+			}
+
+			kip = new PacketKexInit(msg, 0, msglen);
+			kxs.remoteKEX = kip;
+
+			kxs.np = mergeKexParameters(kxs.localKEX.getKexParameters(), kxs.remoteKEX.getKexParameters());
+
+			if (kxs.np == null)
+				throw new IOException("Cannot negotiate, proposals do not match.");
+
+			if (kxs.remoteKEX.isFirst_kex_packet_follows() && (kxs.np.guessOK == false))
+			{
+				/*
+				 * Guess was wrong, we need to ignore the next kex packet.
+				 */
+
+				ignore_next_kex_packet = true;
+			}
+
+			if (kxs.np.kex_algo.equals("diffie-hellman-group-exchange-sha1")
+					|| kxs.np.kex_algo.equals("diffie-hellman-group-exchange-sha256"))
+			{
+				if (kxs.dhgexParameters.getMin_group_len() == 0)
+				{
+					PacketKexDhGexRequestOld dhgexreq = new PacketKexDhGexRequestOld(kxs.dhgexParameters);
+					tm.sendKexMessage(dhgexreq.getPayload());
+
+				}
+				else
+				{
+					PacketKexDhGexRequest dhgexreq = new PacketKexDhGexRequest(kxs.dhgexParameters);
+					tm.sendKexMessage(dhgexreq.getPayload());
+				}
+				if (kxs.np.kex_algo.endsWith("sha1")) {
+					kxs.hashAlgo = "SHA1";
+				} else {
+					kxs.hashAlgo = "SHA-256";
+				}
+				kxs.state = 1;
+				return;
+			}
+
+			if (kxs.np.kex_algo.equals("diffie-hellman-group1-sha1")
+					|| kxs.np.kex_algo.equals("diffie-hellman-group14-sha1"))
+			{
+				kxs.dhx = GenericDhExchange.getInstance(kxs.np.kex_algo);
+
+				kxs.dhx.init(kxs.np.kex_algo);
+				kxs.hashAlgo = kxs.dhx.getHashAlgo();
+
+				PacketKexDHInitNew kp = new PacketKexDHInitNew(kxs.dhx.getE());
+				tm.sendKexMessage(kp.getPayload());
+				kxs.state = 1;
+				return;
+			}
+
+			throw new IllegalStateException("Unkown KEX method!");
+		}
+
+		if (msg[0] == Packets.SSH_MSG_NEWKEYS)
+		{
+			if (km == null)
+				throw new IOException("Peer sent SSH_MSG_NEWKEYS, but I have no key material ready!");
+
+			BlockCipher cbc;
+			MACNew mac;
+
+			try
+			{
+				cbc = BlockCipherFactory.createCipher(kxs.np.enc_algo_server_to_client, false,
+						km.enc_key_server_to_client, km.initial_iv_server_to_client);
+
+				mac = new MACNew(kxs.np.mac_algo_server_to_client, km.integrity_key_server_to_client);
+
+			}
+			catch (IllegalArgumentException e1)
+			{
+				throw new IOException("Fatal error during MAC startup!");
+			}
+
+			tm.changeRecvCipher(cbc, mac);
+
+			ConnectionInfo sci = new ConnectionInfo();
+
+			kexCount++;
+
+			sci.keyExchangeAlgorithm = kxs.np.kex_algo;
+			sci.keyExchangeCounter = kexCount;
+			sci.clientToServerCryptoAlgorithm = kxs.np.enc_algo_client_to_server;
+			sci.serverToClientCryptoAlgorithm = kxs.np.enc_algo_server_to_client;
+			sci.clientToServerMACAlgorithm = kxs.np.mac_algo_client_to_server;
+			sci.serverToClientMACAlgorithm = kxs.np.mac_algo_server_to_client;
+			sci.serverHostKeyAlgorithm = kxs.np.server_host_key_algo;
+			sci.serverHostKey = kxs.hostkey;
+
+			synchronized (accessLock)
+			{
+				lastConnInfo = sci;
+				accessLock.notifyAll();
+			}
+
+			kxs = null;
+			return;
+		}
+
+		if ((kxs == null) || (kxs.state == 0))
+			throw new IOException("Unexpected Kex submessage!");
+
+		if (kxs.np.kex_algo.equals("diffie-hellman-group-exchange-sha1")
+				|| kxs.np.kex_algo.equals("diffie-hellman-group-exchange-sha256"))
+		{
+			if (kxs.state == 1)
+			{
+				PacketKexDhGexGroup dhgexgrp = new PacketKexDhGexGroup(msg, 0, msglen);
+				kxs.dhgx = new DhGroupExchange(dhgexgrp.getP(), dhgexgrp.getG());
+				kxs.dhgx.init(rnd);
+				PacketKexDhGexInit dhgexinit = new PacketKexDhGexInit(kxs.dhgx.getE());
+				tm.sendKexMessage(dhgexinit.getPayload());
+				kxs.state = 2;
+				return;
+			}
+
+			if (kxs.state == 2)
+			{
+				PacketKexDhGexReply dhgexrpl = new PacketKexDhGexReply(msg, 0, msglen);
+
+				kxs.hostkey = dhgexrpl.getHostKey();
+
+				if (verifier != null)
+				{
+					boolean vres = false;
+
+					try
+					{
+						vres = verifier.verifyServerHostKey(hostname, port, kxs.np.server_host_key_algo, kxs.hostkey);
+					}
+					catch (Exception e)
+					{
+						throw (IOException) new IOException(
+								"The server hostkey was not accepted by the verifier callback.").initCause(e);
+					}
+
+					if (vres == false)
+						throw new IOException("The server hostkey was not accepted by the verifier callback");
+				}
+
+				kxs.dhgx.setF(dhgexrpl.getF());
+
+				try
+				{
+					kxs.H = kxs.dhgx.calculateH(kxs.hashAlgo,
+							csh.getClientString(), csh.getServerString(),
+							kxs.localKEX.getPayload(), kxs.remoteKEX.getPayload(), dhgexrpl.getHostKey(),
+							kxs.dhgexParameters);
+				}
+				catch (IllegalArgumentException e)
+				{
+					throw (IOException) new IOException("KEX error.").initCause(e);
+				}
+
+				boolean res = verifySignature(dhgexrpl.getSignature(), kxs.hostkey);
+
+				if (res == false)
+					throw new IOException("Hostkey signature sent by remote is wrong!");
+
+				kxs.K = kxs.dhgx.getK();
+
+				finishKex();
+				kxs.state = -1;
+				return;
+			}
+
+			throw new IllegalStateException("Illegal State in KEX Exchange!");
+		}
+
+		if (kxs.np.kex_algo.equals("diffie-hellman-group1-sha1")
+				|| kxs.np.kex_algo.equals("diffie-hellman-group14-sha1"))
+		{
+			if (kxs.state == 1)
+			{
+
+				PacketKexDHReplyNew dhr = new PacketKexDHReplyNew(msg, 0, msglen);
+
+				kxs.hostkey = dhr.getHostKey();
+
+				if (verifier != null)
+				{
+					boolean vres = false;
+
+					try
+					{
+						vres = verifier.verifyServerHostKey(hostname, port, kxs.np.server_host_key_algo, kxs.hostkey);
+					}
+					catch (Exception e)
+					{
+						throw (IOException) new IOException(
+								"The server hostkey was not accepted by the verifier callback.").initCause(e);
+					}
+
+					if (vres == false)
+						throw new IOException("The server hostkey was not accepted by the verifier callback");
+				}
+
+				kxs.dhx.setF(dhr.getF());
+
+				try
+				{
+					kxs.H = kxs.dhx.calculateH(csh.getClientString(), csh.getServerString(), kxs.localKEX.getPayload(),
+							kxs.remoteKEX.getPayload(), dhr.getHostKey());
+				}
+				catch (IllegalArgumentException e)
+				{
+					throw (IOException) new IOException("KEX error.").initCause(e);
+				}
+
+				boolean res = verifySignature(dhr.getSignature(), kxs.hostkey);
+
+				if (res == false)
+					throw new IOException("Hostkey signature sent by remote is wrong!");
+
+				kxs.K = kxs.dhx.getK();
+
+				finishKex();
+				kxs.state = -1;
+				return;
+			}
+		}
+
+		throw new IllegalStateException("Unkown KEX method! (" + kxs.np.kex_algo + ")");
+	}
+
+    public void handleEndMessage(Throwable cause) throws IOException {
+        synchronized (accessLock) {
+            connectionClosed = true;
+            accessLock.notifyAll();
+        }
+    }
+}

--- a/src/com/trilead/ssh2/transport/KexState.java
+++ b/src/com/trilead/ssh2/transport/KexState.java
@@ -4,8 +4,8 @@ package com.trilead.ssh2.transport;
 import java.math.BigInteger;
 
 import com.trilead.ssh2.DHGexParameters;
+import com.trilead.ssh2.crypto.dh.DhExchange;
 import com.trilead.ssh2.crypto.dh.DhGroupExchange;
-import com.trilead.ssh2.crypto.dh.GenericDhExchange;
 import com.trilead.ssh2.packets.PacketKexInit;
 
 /**
@@ -23,11 +23,10 @@ public class KexState
 
 	public BigInteger K;
 	public byte[] H;
-
+	
 	public byte[] hostkey;
-
-	public String hashAlgo;
-	public GenericDhExchange dhx;
+	
+	public DhExchange dhx;
 	public DhGroupExchange dhgx;
 	public DHGexParameters dhgexParameters;
 }

--- a/src/com/trilead/ssh2/transport/KexState.java
+++ b/src/com/trilead/ssh2/transport/KexState.java
@@ -13,6 +13,8 @@ import com.trilead.ssh2.packets.PacketKexInit;
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: KexState.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
+ *
+ * Deprecated use KexStateNew.
  */
 public class KexState
 {

--- a/src/com/trilead/ssh2/transport/KexStateNew.java
+++ b/src/com/trilead/ssh2/transport/KexStateNew.java
@@ -1,0 +1,30 @@
+package com.trilead.ssh2.transport;
+
+
+import java.math.BigInteger;
+
+import com.trilead.ssh2.DHGexParameters;
+import com.trilead.ssh2.crypto.dh.DhGroupExchange;
+import com.trilead.ssh2.crypto.dh.GenericDhExchange;
+import com.trilead.ssh2.packets.PacketKexInit;
+
+/**
+ * KexStateNew.
+ */
+public class KexStateNew
+{
+	public PacketKexInit localKEX;
+	public PacketKexInit remoteKEX;
+	public NegotiatedParameters np;
+	public int state = 0;
+
+	public BigInteger K;
+	public byte[] H;
+
+	public byte[] hostkey;
+
+	public String hashAlgo;
+	public GenericDhExchange dhx;
+	public DhGroupExchange dhgx;
+	public DHGexParameters dhgexParameters;
+}

--- a/src/com/trilead/ssh2/transport/TransportConnection.java
+++ b/src/com/trilead/ssh2/transport/TransportConnection.java
@@ -10,7 +10,7 @@ import com.trilead.ssh2.crypto.cipher.BlockCipher;
 import com.trilead.ssh2.crypto.cipher.CipherInputStream;
 import com.trilead.ssh2.crypto.cipher.CipherOutputStream;
 import com.trilead.ssh2.crypto.cipher.NullCipher;
-import com.trilead.ssh2.crypto.digest.MAC;
+import com.trilead.ssh2.crypto.digest.MACNew;
 import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.Packets;
 
@@ -37,13 +37,13 @@ public class TransportConnection
 
 	/* Depends on current MAC and CIPHER */
 
-	MAC send_mac;
+	MACNew send_mac;
 
 	byte[] send_mac_buffer;
 
 	int send_padd_blocksize = 8;
 
-	MAC recv_mac;
+	MACNew recv_mac;
 
 	byte[] recv_mac_buffer;
 
@@ -74,7 +74,7 @@ public class TransportConnection
 		this.rnd = rnd;
 	}
 
-	public void changeRecvCipher(BlockCipher bc, MAC mac)
+	public void changeRecvCipher(BlockCipher bc, MACNew mac)
 	{
 		cis.changeCipher(bc);
 		recv_mac = mac;
@@ -85,7 +85,7 @@ public class TransportConnection
 			recv_padd_blocksize = 8;
 	}
 
-	public void changeSendCipher(BlockCipher bc, MAC mac)
+	public void changeSendCipher(BlockCipher bc, MACNew mac)
 	{
 		if ((bc instanceof NullCipher) == false)
 		{

--- a/src/com/trilead/ssh2/transport/TransportConnection.java
+++ b/src/com/trilead/ssh2/transport/TransportConnection.java
@@ -20,6 +20,8 @@ import com.trilead.ssh2.packets.Packets;
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: TransportConnection.java,v 1.1 2007/10/15 12:49:56 cplattne Exp $
+ *
+ * Deprecated use TransportConnectionNew.
  */
 public class TransportConnection
 {

--- a/src/com/trilead/ssh2/transport/TransportConnection.java
+++ b/src/com/trilead/ssh2/transport/TransportConnection.java
@@ -10,7 +10,7 @@ import com.trilead.ssh2.crypto.cipher.BlockCipher;
 import com.trilead.ssh2.crypto.cipher.CipherInputStream;
 import com.trilead.ssh2.crypto.cipher.CipherOutputStream;
 import com.trilead.ssh2.crypto.cipher.NullCipher;
-import com.trilead.ssh2.crypto.digest.MACNew;
+import com.trilead.ssh2.crypto.digest.MAC;
 import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.Packets;
 
@@ -37,13 +37,13 @@ public class TransportConnection
 
 	/* Depends on current MAC and CIPHER */
 
-	MACNew send_mac;
+	MAC send_mac;
 
 	byte[] send_mac_buffer;
 
 	int send_padd_blocksize = 8;
 
-	MACNew recv_mac;
+	MAC recv_mac;
 
 	byte[] recv_mac_buffer;
 
@@ -74,7 +74,7 @@ public class TransportConnection
 		this.rnd = rnd;
 	}
 
-	public void changeRecvCipher(BlockCipher bc, MACNew mac)
+	public void changeRecvCipher(BlockCipher bc, MAC mac)
 	{
 		cis.changeCipher(bc);
 		recv_mac = mac;
@@ -85,7 +85,7 @@ public class TransportConnection
 			recv_padd_blocksize = 8;
 	}
 
-	public void changeSendCipher(BlockCipher bc, MACNew mac)
+	public void changeSendCipher(BlockCipher bc, MAC mac)
 	{
 		if ((bc instanceof NullCipher) == false)
 		{

--- a/src/com/trilead/ssh2/transport/TransportConnectionNew.java
+++ b/src/com/trilead/ssh2/transport/TransportConnectionNew.java
@@ -211,7 +211,7 @@ public class TransportConnectionNew
 
 		int padding_length = recv_packet_header_buffer[4] & 0xff;
 
-		if (packet_length > TransportManager.MAX_PACKET_SIZE || packet_length < 12)
+		if (packet_length > TransportManagerNew.MAX_PACKET_SIZE || packet_length < 12)
 			throw new IOException("Illegal packet size! (" + packet_length + ")");
 
 		int payload_length = packet_length - padding_length - 1;
@@ -237,7 +237,7 @@ public class TransportConnectionNew
 
 		int padding_length = recv_packet_header_buffer[4] & 0xff;
 
-		if (packet_length > TransportManager.MAX_PACKET_SIZE || packet_length < 12)
+		if (packet_length > TransportManagerNew.MAX_PACKET_SIZE || packet_length < 12)
 			throw new IOException("Illegal packet size! (" + packet_length + ")");
 
 		int payload_length = packet_length - padding_length - 1;

--- a/src/com/trilead/ssh2/transport/TransportConnectionNew.java
+++ b/src/com/trilead/ssh2/transport/TransportConnectionNew.java
@@ -1,0 +1,281 @@
+
+package com.trilead.ssh2.transport;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.SecureRandom;
+
+import com.trilead.ssh2.crypto.cipher.BlockCipher;
+import com.trilead.ssh2.crypto.cipher.CipherInputStream;
+import com.trilead.ssh2.crypto.cipher.CipherOutputStream;
+import com.trilead.ssh2.crypto.cipher.NullCipher;
+import com.trilead.ssh2.crypto.digest.MACNew;
+import com.trilead.ssh2.log.Logger;
+import com.trilead.ssh2.packets.Packets;
+
+
+/**
+ * TransportConnectionNew.
+ */
+public class TransportConnectionNew
+{
+	private static final Logger log = Logger.getLogger(TransportConnection.class);
+
+	int send_seq_number = 0;
+
+	int recv_seq_number = 0;
+
+	CipherInputStream cis;
+
+	CipherOutputStream cos;
+
+	boolean useRandomPadding = false;
+
+	/* Depends on current MAC and CIPHER */
+
+	MACNew send_mac;
+
+	byte[] send_mac_buffer;
+
+	int send_padd_blocksize = 8;
+
+	MACNew recv_mac;
+
+	byte[] recv_mac_buffer;
+
+	byte[] recv_mac_buffer_cmp;
+
+	int recv_padd_blocksize = 8;
+
+	/* won't change */
+
+	final byte[] send_padding_buffer = new byte[256];
+
+	final byte[] send_packet_header_buffer = new byte[5];
+
+	final byte[] recv_padding_buffer = new byte[256];
+
+	final byte[] recv_packet_header_buffer = new byte[5];
+
+	boolean recv_packet_header_present = false;
+
+	ClientServerHello csh;
+
+	final SecureRandom rnd;
+
+	public TransportConnectionNew(InputStream is, OutputStream os, SecureRandom rnd)
+	{
+		this.cis = new CipherInputStream(new NullCipher(), is);
+		this.cos = new CipherOutputStream(new NullCipher(), os);
+		this.rnd = rnd;
+	}
+
+	public void changeRecvCipher(BlockCipher bc, MACNew mac)
+	{
+		cis.changeCipher(bc);
+		recv_mac = mac;
+		recv_mac_buffer = (mac != null) ? new byte[mac.size()] : null;
+		recv_mac_buffer_cmp = (mac != null) ? new byte[mac.size()] : null;
+		recv_padd_blocksize = bc.getBlockSize();
+		if (recv_padd_blocksize < 8)
+			recv_padd_blocksize = 8;
+	}
+
+	public void changeSendCipher(BlockCipher bc, MACNew mac)
+	{
+		if ((bc instanceof NullCipher) == false)
+		{
+			/* Only use zero byte padding for the first few packets */
+			useRandomPadding = true;
+			/* Once we start encrypting, there is no way back */
+		}
+
+		cos.changeCipher(bc);
+		send_mac = mac;
+		send_mac_buffer = (mac != null) ? new byte[mac.size()] : null;
+		send_padd_blocksize = bc.getBlockSize();
+		if (send_padd_blocksize < 8)
+			send_padd_blocksize = 8;
+	}
+
+	public void sendMessage(byte[] message) throws IOException
+	{
+		sendMessage(message, 0, message.length, 0);
+	}
+
+	public void sendMessage(byte[] message, int off, int len) throws IOException
+	{
+		sendMessage(message, off, len, 0);
+	}
+
+	public int getPacketOverheadEstimate()
+	{
+		// return an estimate for the paket overhead (for send operations)
+		return 5 + 4 + (send_padd_blocksize - 1) + send_mac_buffer.length;
+	}
+
+	public void sendMessage(byte[] message, int off, int len, int padd) throws IOException
+	{
+		if (padd < 4)
+			padd = 4;
+		else if (padd > 64)
+			padd = 64;
+
+		int packet_len = 5 + len + padd; /* Minimum allowed padding is 4 */
+
+		int slack = packet_len % send_padd_blocksize;
+
+		if (slack != 0)
+		{
+			packet_len += (send_padd_blocksize - slack);
+		}
+
+		if (packet_len < 16)
+			packet_len = 16;
+
+		int padd_len = packet_len - (5 + len);
+
+		if (useRandomPadding)
+		{
+			for (int i = 0; i < padd_len; i = i + 4)
+			{
+				/*
+				 * don't waste calls to rnd.nextInt() (by using only 8bit of the
+				 * output). just believe me: even though we may write here up to 3
+				 * bytes which won't be used, there is no "buffer overflow" (i.e.,
+				 * arrayindexoutofbounds). the padding buffer is big enough =) (256
+				 * bytes, and that is bigger than any current cipher block size + 64).
+				 */
+
+				int r = rnd.nextInt();
+				send_padding_buffer[i] = (byte) r;
+				send_padding_buffer[i + 1] = (byte) (r >> 8);
+				send_padding_buffer[i + 2] = (byte) (r >> 16);
+				send_padding_buffer[i + 3] = (byte) (r >> 24);
+			}
+		}
+		else
+		{
+			/* use zero padding for unencrypted traffic */
+			for (int i = 0; i < padd_len; i++)
+				send_padding_buffer[i] = 0;
+			/* Actually this code is paranoid: we never filled any
+			 * bytes into the padding buffer so far, therefore it should
+			 * consist of zeros only.
+			 */
+		}
+
+		send_packet_header_buffer[0] = (byte) ((packet_len - 4) >> 24);
+		send_packet_header_buffer[1] = (byte) ((packet_len - 4) >> 16);
+		send_packet_header_buffer[2] = (byte) ((packet_len - 4) >> 8);
+		send_packet_header_buffer[3] = (byte) ((packet_len - 4));
+		send_packet_header_buffer[4] = (byte) padd_len;
+
+		cos.write(send_packet_header_buffer, 0, 5);
+		cos.write(message, off, len);
+		cos.write(send_padding_buffer, 0, padd_len);
+
+		if (send_mac != null)
+		{
+			send_mac.initMac(send_seq_number);
+			send_mac.update(send_packet_header_buffer, 0, 5);
+			send_mac.update(message, off, len);
+			send_mac.update(send_padding_buffer, 0, padd_len);
+
+			send_mac.getMac(send_mac_buffer, 0);
+			cos.writePlain(send_mac_buffer, 0, send_mac_buffer.length);
+		}
+
+		cos.flush();
+
+		if (log.isEnabled())
+		{
+			log.log(90, "Sent " + Packets.getMessageName(message[off] & 0xff) + " " + len + " bytes payload");
+		}
+
+		send_seq_number++;
+	}
+
+	public int peekNextMessageLength() throws IOException
+	{
+		if (recv_packet_header_present == false)
+		{
+			cis.read(recv_packet_header_buffer, 0, 5);
+			recv_packet_header_present = true;
+		}
+
+		int packet_length = ((recv_packet_header_buffer[0] & 0xff) << 24)
+				| ((recv_packet_header_buffer[1] & 0xff) << 16) | ((recv_packet_header_buffer[2] & 0xff) << 8)
+				| ((recv_packet_header_buffer[3] & 0xff));
+
+		int padding_length = recv_packet_header_buffer[4] & 0xff;
+
+		if (packet_length > TransportManager.MAX_PACKET_SIZE || packet_length < 12)
+			throw new IOException("Illegal packet size! (" + packet_length + ")");
+
+		int payload_length = packet_length - padding_length - 1;
+
+		if (payload_length < 0)
+			throw new IOException("Illegal padding_length in packet from remote (" + padding_length + ")");
+
+		return payload_length;
+	}
+
+	public int receiveMessage(byte buffer[], int off, int len) throws IOException
+	{
+		if (recv_packet_header_present == false)
+		{
+			cis.read(recv_packet_header_buffer, 0, 5);
+		}
+		else
+			recv_packet_header_present = false;
+
+		int packet_length = ((recv_packet_header_buffer[0] & 0xff) << 24)
+				| ((recv_packet_header_buffer[1] & 0xff) << 16) | ((recv_packet_header_buffer[2] & 0xff) << 8)
+				| ((recv_packet_header_buffer[3] & 0xff));
+
+		int padding_length = recv_packet_header_buffer[4] & 0xff;
+
+		if (packet_length > TransportManager.MAX_PACKET_SIZE || packet_length < 12)
+			throw new IOException("Illegal packet size! (" + packet_length + ")");
+
+		int payload_length = packet_length - padding_length - 1;
+
+		if (payload_length < 0)
+			throw new IOException("Illegal padding_length in packet from remote (" + padding_length + ")");
+
+		if (payload_length >= len)
+			throw new IOException("Receive buffer too small (" + len + ", need " + payload_length + ")");
+
+		cis.read(buffer, off, payload_length);
+		cis.read(recv_padding_buffer, 0, padding_length);
+
+		if (recv_mac != null)
+		{
+			cis.readPlain(recv_mac_buffer, 0, recv_mac_buffer.length);
+
+			recv_mac.initMac(recv_seq_number);
+			recv_mac.update(recv_packet_header_buffer, 0, 5);
+			recv_mac.update(buffer, off, payload_length);
+			recv_mac.update(recv_padding_buffer, 0, padding_length);
+			recv_mac.getMac(recv_mac_buffer_cmp, 0);
+
+			for (int i = 0; i < recv_mac_buffer.length; i++)
+			{
+				if (recv_mac_buffer[i] != recv_mac_buffer_cmp[i])
+					throw new IOException("Remote sent corrupt MAC.");
+			}
+		}
+
+		recv_seq_number++;
+
+		if (log.isEnabled())
+		{
+			log.log(90, "Received " + Packets.getMessageName(buffer[off] & 0xff) + " " + payload_length
+					+ " bytes payload");
+		}
+
+		return payload_length;
+	}
+}

--- a/src/com/trilead/ssh2/transport/TransportManager.java
+++ b/src/com/trilead/ssh2/transport/TransportManager.java
@@ -21,7 +21,7 @@ import com.trilead.ssh2.ServerHostKeyVerifier;
 import com.trilead.ssh2.crypto.Base64;
 import com.trilead.ssh2.crypto.CryptoWishList;
 import com.trilead.ssh2.crypto.cipher.BlockCipher;
-import com.trilead.ssh2.crypto.digest.MACNew;
+import com.trilead.ssh2.crypto.digest.MAC;
 import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.PacketDisconnect;
 import com.trilead.ssh2.packets.Packets;
@@ -50,6 +50,8 @@ import com.trilead.ssh2.util.Tokenizer;
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: TransportManager.java,v 1.2 2008/04/01 12:38:09 cplattne Exp $
+ *
+ * Deprecated use TransportManagerNew.
  */
 public class TransportManager
 {
@@ -602,12 +604,12 @@ public class TransportManager
 		km.initiateKEX(cwl, dhgex);
 	}
 
-	public void changeRecvCipher(BlockCipher bc, MACNew mac)
+	public void changeRecvCipher(BlockCipher bc, MAC mac)
 	{
 		tc.changeRecvCipher(bc, mac);
 	}
 
-	public void changeSendCipher(BlockCipher bc, MACNew mac)
+	public void changeSendCipher(BlockCipher bc, MAC mac)
 	{
 		tc.changeSendCipher(bc, mac);
 	}

--- a/src/com/trilead/ssh2/transport/TransportManager.java
+++ b/src/com/trilead/ssh2/transport/TransportManager.java
@@ -21,7 +21,7 @@ import com.trilead.ssh2.ServerHostKeyVerifier;
 import com.trilead.ssh2.crypto.Base64;
 import com.trilead.ssh2.crypto.CryptoWishList;
 import com.trilead.ssh2.crypto.cipher.BlockCipher;
-import com.trilead.ssh2.crypto.digest.MAC;
+import com.trilead.ssh2.crypto.digest.MACNew;
 import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.PacketDisconnect;
 import com.trilead.ssh2.packets.Packets;
@@ -602,12 +602,12 @@ public class TransportManager
 		km.initiateKEX(cwl, dhgex);
 	}
 
-	public void changeRecvCipher(BlockCipher bc, MAC mac)
+	public void changeRecvCipher(BlockCipher bc, MACNew mac)
 	{
 		tc.changeRecvCipher(bc, mac);
 	}
 
-	public void changeSendCipher(BlockCipher bc, MAC mac)
+	public void changeSendCipher(BlockCipher bc, MACNew mac)
 	{
 		tc.changeSendCipher(bc, mac);
 	}

--- a/src/com/trilead/ssh2/transport/TransportManagerNew.java
+++ b/src/com/trilead/ssh2/transport/TransportManagerNew.java
@@ -1,0 +1,803 @@
+package com.trilead.ssh2.transport;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.InterruptedIOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.SecureRandom;
+import java.util.Vector;
+
+import com.trilead.ssh2.ConnectionInfo;
+import com.trilead.ssh2.ConnectionMonitor;
+import com.trilead.ssh2.DHGexParameters;
+import com.trilead.ssh2.HTTPProxyData;
+import com.trilead.ssh2.HTTPProxyException;
+import com.trilead.ssh2.ProxyData;
+import com.trilead.ssh2.ServerHostKeyVerifier;
+import com.trilead.ssh2.crypto.Base64;
+import com.trilead.ssh2.crypto.CryptoWishList;
+import com.trilead.ssh2.crypto.cipher.BlockCipher;
+import com.trilead.ssh2.crypto.digest.MACNew;
+import com.trilead.ssh2.log.Logger;
+import com.trilead.ssh2.packets.PacketDisconnect;
+import com.trilead.ssh2.packets.Packets;
+import com.trilead.ssh2.packets.TypesReader;
+import com.trilead.ssh2.util.Tokenizer;
+
+
+/*
+ * Yes, the "standard" is a big mess. On one side, the say that arbitary channel
+ * packets are allowed during kex exchange, on the other side we need to blindly
+ * ignore the next _packet_ if the KEX guess was wrong. Where do we know from that
+ * the next packet is not a channel data packet? Yes, we could check if it is in
+ * the KEX range. But the standard says nothing about this. The OpenSSH guys
+ * block local "normal" traffic during KEX. That's fine - however, they assume
+ * that the other side is doing the same. During re-key, if they receive traffic
+ * other than KEX, they become horribly irritated and kill the connection. Since
+ * we are very likely going to communicate with OpenSSH servers, we have to play
+ * the same game - even though we could do better.
+ * 
+ * btw: having stdout and stderr on the same channel, with a shared window, is
+ * also a VERY good idea... =(
+ */
+
+/**
+ * TransportManagerNew.
+ */
+public class TransportManagerNew
+{
+    private static final Logger log = Logger.getLogger(TransportManager.class);
+
+    class HandlerEntry
+	{
+		MessageHandler mh;
+		int low;
+		int high;
+	}
+
+	private final Vector asynchronousQueue = new Vector();
+	private Thread asynchronousThread = null;
+
+	class AsynchronousWorker extends Thread
+	{
+		public void run()
+		{
+			while (true)
+			{
+				byte[] msg = null;
+
+				synchronized (asynchronousQueue)
+				{
+					if (asynchronousQueue.size() == 0)
+					{
+						/* After the queue is empty for about 2 seconds, stop this thread */
+
+						try
+						{
+							asynchronousQueue.wait(2000);
+						}
+						catch (InterruptedException e)
+						{
+							/* OKOK, if somebody interrupts us, then we may die earlier. */
+						}
+
+						if (asynchronousQueue.size() == 0)
+						{
+							asynchronousThread = null;
+							return;
+						}
+					}
+
+					msg = (byte[]) asynchronousQueue.remove(0);
+				}
+
+				/* The following invocation may throw an IOException.
+				 * There is no point in handling it - it simply means
+				 * that the connection has a problem and we should stop
+				 * sending asynchronously messages. We do not need to signal that
+				 * we have exited (asynchronousThread = null): further
+				 * messages in the queue cannot be sent by this or any
+				 * other thread.
+				 * Other threads will sooner or later (when receiving or
+				 * sending the next message) get the same IOException and
+				 * get to the same conclusion.
+				 */
+
+				try
+				{
+					sendMessage(msg);
+				}
+				catch (IOException e)
+				{
+					return;
+				}
+			}
+		}
+	}
+
+	String hostname;
+	int port;
+	final Socket sock = new Socket();
+
+	final Object connectionSemaphore = new Object();
+
+	boolean flagKexOngoing = false;
+
+	Throwable reasonClosedCause = null;
+
+	TransportConnectionNew tc;
+	KexManager km;
+
+	Vector messageHandlers = new Vector();
+
+	Thread receiveThread;
+
+	Vector connectionMonitors = new Vector();
+	boolean monitorsWereInformed = false;
+	private ClientServerHello versions;
+
+	/**
+	 * There were reports that there are JDKs which use
+	 * the resolver even though one supplies a dotted IP
+	 * address in the Socket constructor. That is why we
+	 * try to generate the InetAdress "by hand".
+	 * 
+	 * @param host
+	 * @return the InetAddress
+	 * @throws UnknownHostException
+	 */
+	private InetAddress createInetAddress(String host) throws UnknownHostException
+	{
+		/* Check if it is a dotted IP4 address */
+
+		InetAddress addr = parseIPv4Address(host);
+
+		if (addr != null)
+			return addr;
+
+		return InetAddress.getByName(host);
+	}
+
+	private InetAddress parseIPv4Address(String host) throws UnknownHostException
+	{
+		if (host == null)
+			return null;
+
+		String[] quad = Tokenizer.parseTokens(host, '.');
+
+		if ((quad == null) || (quad.length != 4))
+			return null;
+
+		byte[] addr = new byte[4];
+
+		for (int i = 0; i < 4; i++)
+		{
+			int part = 0;
+
+			if ((quad[i].length() == 0) || (quad[i].length() > 3))
+				return null;
+
+			for (int k = 0; k < quad[i].length(); k++)
+			{
+				char c = quad[i].charAt(k);
+
+				/* No, Character.isDigit is not the same */
+				if ((c < '0') || (c > '9'))
+					return null;
+
+				part = part * 10 + (c - '0');
+			}
+
+			if (part > 255) /* 300.1.2.3 is invalid =) */
+				return null;
+
+			addr[i] = (byte) part;
+		}
+
+		return InetAddress.getByAddress(host, addr);
+	}
+
+	public TransportManagerNew(String host, int port) throws IOException
+	{
+		this.hostname = host;
+		this.port = port;
+	}
+
+	public int getPacketOverheadEstimate()
+	{
+		return tc.getPacketOverheadEstimate();
+	}
+
+	public void setTcpNoDelay(boolean state) throws IOException
+	{
+		sock.setTcpNoDelay(state);
+	}
+
+	public void setSoTimeout(int timeout) throws IOException
+	{
+		sock.setSoTimeout(timeout);
+	}
+
+	public ConnectionInfo getConnectionInfo(int kexNumber) throws IOException
+	{
+		return km.getOrWaitForConnectionInfo(kexNumber);
+	}
+	
+	public ClientServerHello getVersionInfo() {
+		return versions;
+	}
+
+    /**
+     * If the socket connection is lost (either by this side closing down or the other side closing down),
+     * return a non-null object indicating the cause of the connection loss.
+     */
+	public Throwable getReasonClosedCause()
+	{
+		synchronized (connectionSemaphore)
+		{
+			return reasonClosedCause;
+		}
+	}
+
+    public boolean isConnectionClosed() {
+        return getReasonClosedCause()!=null;
+    }
+
+	public byte[] getSessionIdentifier()
+	{
+		return km.sessionId;
+	}
+
+	public void close(Throwable cause, boolean useDisconnectPacket)
+	{
+		if (useDisconnectPacket == false)
+		{
+			/* OK, hard shutdown - do not aquire the semaphore,
+			 * perhaps somebody is inside (and waits until the remote
+			 * side is ready to accept new data). */
+
+			try
+			{
+				sock.close();
+			}
+			catch (IOException ignore)
+			{
+			}
+
+			/* OK, whoever tried to send data, should now agree that
+			 * there is no point in further waiting =)
+			 * It is safe now to aquire the semaphore.
+			 */
+		}
+
+		synchronized (connectionSemaphore)
+		{
+			if (reasonClosedCause==null)
+			{
+				if (useDisconnectPacket == true)
+				{
+					try
+					{
+						byte[] msg = new PacketDisconnect(Packets.SSH_DISCONNECT_BY_APPLICATION, cause.getMessage(), "")
+								.getPayload();
+						if (tc != null)
+							tc.sendMessage(msg);
+					}
+					catch (IOException ignore)
+					{
+					}
+
+					try
+					{
+						sock.close();
+					}
+					catch (IOException ignore)
+					{
+					}
+				}
+
+                if (cause==null)
+                    cause = new Exception("Unknown cause");
+				reasonClosedCause = cause;
+			}
+			connectionSemaphore.notifyAll();
+		}
+
+		/* No check if we need to inform the monitors */
+
+		Vector monitors = null;
+
+		synchronized (this)
+		{
+			/* Short term lock to protect "connectionMonitors"
+			 * and "monitorsWereInformed"
+			 * (they may be modified concurrently)
+			 */
+
+			if (monitorsWereInformed == false)
+			{
+				monitorsWereInformed = true;
+				monitors = (Vector) connectionMonitors.clone();
+			}
+		}
+
+		if (monitors != null)
+		{
+			for (int i = 0; i < monitors.size(); i++)
+			{
+				try
+				{
+					ConnectionMonitor cmon = (ConnectionMonitor) monitors.elementAt(i);
+					cmon.connectionLost(reasonClosedCause);
+				}
+				catch (Exception ignore)
+				{
+				}
+			}
+		}
+	}
+
+	private void establishConnection(ProxyData proxyData, int connectTimeout, int readTimeout) throws IOException
+	{
+		/* See the comment for createInetAddress() */
+
+		if (proxyData == null)
+		{
+			InetAddress addr = createInetAddress(hostname);
+			sock.connect(new InetSocketAddress(addr, port), connectTimeout);
+			sock.setSoTimeout(readTimeout);
+			return;
+		}
+
+		if (proxyData instanceof HTTPProxyData)
+		{
+			HTTPProxyData pd = (HTTPProxyData) proxyData;
+
+			/* At the moment, we only support HTTP proxies */
+
+			InetAddress addr = createInetAddress(pd.proxyHost);
+			sock.connect(new InetSocketAddress(addr, pd.proxyPort), connectTimeout);
+			sock.setSoTimeout(readTimeout);
+
+			/* OK, now tell the proxy where we actually want to connect to */
+
+			StringBuffer sb = new StringBuffer();
+
+			sb.append("CONNECT ");
+			sb.append(hostname);
+			sb.append(':');
+			sb.append(port);
+			sb.append(" HTTP/1.0\r\n");
+
+			if ((pd.proxyUser != null) && (pd.proxyPass != null))
+			{
+				String credentials = pd.proxyUser + ":" + pd.proxyPass;
+				char[] encoded = Base64.encode(credentials.getBytes("ISO-8859-1"));
+				sb.append("Proxy-Authorization: Basic ");
+				sb.append(encoded);
+				sb.append("\r\n");
+			}
+
+			if (pd.requestHeaderLines != null)
+			{
+				for (int i = 0; i < pd.requestHeaderLines.length; i++)
+				{
+					if (pd.requestHeaderLines[i] != null)
+					{
+						sb.append(pd.requestHeaderLines[i]);
+						sb.append("\r\n");
+					}
+				}
+			}
+
+			sb.append("\r\n");
+
+			OutputStream out = sock.getOutputStream();
+
+			out.write(sb.toString().getBytes("ISO-8859-1"));
+			out.flush();
+
+			/* Now parse the HTTP response */
+
+			byte[] buffer = new byte[1024];
+			InputStream in = sock.getInputStream();
+
+			int len = ClientServerHello.readLineRN(in, buffer);
+
+			String httpReponse = new String(buffer, 0, len, "ISO-8859-1");
+
+			if (httpReponse.startsWith("HTTP/") == false)
+				throw new IOException("The proxy did not send back a valid HTTP response.");
+
+			/* "HTTP/1.X XYZ X" => 14 characters minimum */
+
+			if ((httpReponse.length() < 14) || (httpReponse.charAt(8) != ' ') || (httpReponse.charAt(12) != ' '))
+				throw new IOException("The proxy did not send back a valid HTTP response.");
+
+			int errorCode = 0;
+
+			try
+			{
+				errorCode = Integer.parseInt(httpReponse.substring(9, 12));
+			}
+			catch (NumberFormatException ignore)
+			{
+				throw new IOException("The proxy did not send back a valid HTTP response.");
+			}
+
+			if ((errorCode < 0) || (errorCode > 999))
+				throw new IOException("The proxy did not send back a valid HTTP response.");
+
+			if (errorCode != 200)
+			{
+				throw new HTTPProxyException(httpReponse.substring(13), errorCode);
+			}
+
+			/* OK, read until empty line */
+
+			while (true)
+			{
+				len = ClientServerHello.readLineRN(in, buffer);
+				if (len == 0)
+					break;
+			}
+			return;
+		}
+
+		throw new IOException("Unsupported ProxyData");
+	}
+
+    public void initialize(CryptoWishList cwl, ServerHostKeyVerifier verifier, DHGexParameters dhgex,
+            int connectTimeout, SecureRandom rnd, ProxyData proxyData) throws IOException {
+        initialize(cwl, verifier, dhgex, connectTimeout, 0, rnd, proxyData);
+    }
+    
+    public void initialize(CryptoWishList cwl, ServerHostKeyVerifier verifier, DHGexParameters dhgex,
+			int connectTimeout, int readTimeout, SecureRandom rnd, ProxyData proxyData) throws IOException
+	{
+		/* First, establish the TCP connection to the SSH-2 server */
+
+		establishConnection(proxyData, connectTimeout, readTimeout);
+
+		/* Parse the server line and say hello - important: this information is later needed for the
+		 * key exchange (to stop man-in-the-middle attacks) - that is why we wrap it into an object
+		 * for later use.
+		 */
+
+		ClientServerHello csh = new ClientServerHello(sock.getInputStream(), sock.getOutputStream());
+		versions = csh;
+
+		tc = new TransportConnectionNew(sock.getInputStream(), sock.getOutputStream(), rnd);
+
+		km = new KexManager(this, csh, cwl, hostname, port, verifier, rnd);
+		km.initiateKEX(cwl, dhgex);
+
+		receiveThread = new Thread(new Runnable()
+		{
+			public void run()
+			{
+                Throwable cause;
+				try
+				{
+					receiveLoop();
+                    cause = new AssertionError();   // receiveLoop never returns normally
+				}
+				catch (IOException e)
+				{
+                    if (log.isEnabled() && !isConnectionClosed())
+                        log.log(10, "Receive thread: error in receiveLoop",e);
+
+                    cause = e;
+					close(e, false);
+				}
+
+				if (log.isEnabled())
+					log.log(50, "Receive thread: back from receiveLoop");
+
+				/* Tell all handlers that it is time to say goodbye */
+
+				if (km != null)
+				{
+					try
+					{
+						km.handleEndMessage(cause);
+					}
+					catch (IOException e)
+					{
+					}
+				}
+
+				for (int i = 0; i < messageHandlers.size(); i++)
+				{
+					HandlerEntry he = (HandlerEntry) messageHandlers.elementAt(i);
+					try
+					{
+						he.mh.handleEndMessage(cause);
+					}
+					catch (Exception ignore)
+					{
+					}
+				}
+			}
+		});
+
+		receiveThread.setDaemon(true);
+		receiveThread.start();
+	}
+
+	public void registerMessageHandler(MessageHandler mh, int low, int high)
+	{
+		HandlerEntry he = new HandlerEntry();
+		he.mh = mh;
+		he.low = low;
+		he.high = high;
+
+		synchronized (messageHandlers)
+		{
+			messageHandlers.addElement(he);
+		}
+	}
+
+	public void removeMessageHandler(MessageHandler mh, int low, int high)
+	{
+		synchronized (messageHandlers)
+		{
+			for (int i = 0; i < messageHandlers.size(); i++)
+			{
+				HandlerEntry he = (HandlerEntry) messageHandlers.elementAt(i);
+				if ((he.mh == mh) && (he.low == low) && (he.high == high))
+				{
+					messageHandlers.removeElementAt(i);
+					break;
+				}
+			}
+		}
+	}
+
+	public void sendKexMessage(byte[] msg) throws IOException
+	{
+		synchronized (connectionSemaphore)
+		{
+            ensureConnected();
+
+            flagKexOngoing = true;
+
+			try
+			{
+				tc.sendMessage(msg);
+			}
+			catch (IOException e)
+			{
+				close(e, false);
+				throw e;
+			}
+		}
+	}
+
+    private void ensureConnected() throws IOException {
+        if (reasonClosedCause!=null)
+        {
+            throw (IOException) new IOException("Sorry, this connection is closed.").initCause(reasonClosedCause);
+        }
+    }
+
+    public void kexFinished() throws IOException
+	{
+		synchronized (connectionSemaphore)
+		{
+			flagKexOngoing = false;
+			connectionSemaphore.notifyAll();
+		}
+	}
+
+	public void forceKeyExchange(CryptoWishList cwl, DHGexParameters dhgex) throws IOException
+	{
+		km.initiateKEX(cwl, dhgex);
+	}
+
+	public void changeRecvCipher(BlockCipher bc, MACNew mac)
+	{
+		tc.changeRecvCipher(bc, mac);
+	}
+
+	public void changeSendCipher(BlockCipher bc, MACNew mac)
+	{
+		tc.changeSendCipher(bc, mac);
+	}
+
+	public void sendAsynchronousMessage(byte[] msg) throws IOException
+	{
+		synchronized (asynchronousQueue)
+		{
+			asynchronousQueue.addElement(msg);
+
+			/* This limit should be flexible enough. We need this, otherwise the peer
+			 * can flood us with global requests (and other stuff where we have to reply
+			 * with an asynchronous message) and (if the server just sends data and does not
+			 * read what we send) this will probably put us in a low memory situation
+			 * (our send queue would grow and grow and...) */
+
+			if (asynchronousQueue.size() > 100)
+				throw new IOException("Error: the peer is not consuming our asynchronous replies.");
+
+			/* Check if we have an asynchronous sending thread */
+
+			if (asynchronousThread == null)
+			{
+				asynchronousThread = new AsynchronousWorker();
+				asynchronousThread.setDaemon(true);
+				asynchronousThread.start();
+
+				/* The thread will stop after 2 seconds of inactivity (i.e., empty queue) */
+			}
+		}
+	}
+
+	public void setConnectionMonitors(Vector monitors)
+	{
+		synchronized (this)
+		{
+			connectionMonitors = (Vector) monitors.clone();
+		}
+	}
+
+	public void sendMessage(byte[] msg) throws IOException
+	{
+		if (Thread.currentThread() == receiveThread)
+			throw new IOException("Assertion error: sendMessage may never be invoked by the receiver thread!");
+
+		synchronized (connectionSemaphore)
+		{
+			while (true)
+			{
+                ensureConnected();
+
+                if (flagKexOngoing == false)
+					break;
+
+				try
+				{
+					connectionSemaphore.wait();
+				}
+				catch (InterruptedException e)
+				{
+					throw new InterruptedIOException();
+				}
+			}
+
+			try
+			{
+				tc.sendMessage(msg);
+			}
+			catch (IOException e)
+			{
+				close(e, false);
+				throw e;
+			}
+		}
+	}
+
+	public void receiveLoop() throws IOException
+	{
+		byte[] msg = new byte[MAX_PACKET_SIZE];
+
+		while (true)
+		{
+			int msglen = tc.receiveMessage(msg, 0, msg.length);
+
+			int type = msg[0] & 0xff;
+
+			if (type == Packets.SSH_MSG_IGNORE)
+				continue;
+
+			if (type == Packets.SSH_MSG_DEBUG)
+			{
+				if (log.isEnabled())
+				{
+					TypesReader tr = new TypesReader(msg, 0, msglen);
+					tr.readByte();
+					tr.readBoolean();
+					StringBuffer debugMessageBuffer = new StringBuffer();
+					debugMessageBuffer.append(tr.readString("UTF-8"));
+
+					for (int i = 0; i < debugMessageBuffer.length(); i++)
+					{
+						char c = debugMessageBuffer.charAt(i);
+
+						if ((c >= 32) && (c <= 126))
+							continue;
+						debugMessageBuffer.setCharAt(i, '\uFFFD');
+					}
+
+					log.log(50, "DEBUG Message from remote: '" + debugMessageBuffer.toString() + "'");
+				}
+				continue;
+			}
+
+			if (type == Packets.SSH_MSG_UNIMPLEMENTED)
+			{
+				throw new IOException("Peer sent UNIMPLEMENTED message, that should not happen.");
+			}
+
+			if (type == Packets.SSH_MSG_DISCONNECT)
+			{
+				TypesReader tr = new TypesReader(msg, 0, msglen);
+				tr.readByte();
+				int reason_code = tr.readUINT32();
+				StringBuffer reasonBuffer = new StringBuffer();
+				reasonBuffer.append(tr.readString("UTF-8"));
+
+				/*
+				 * Do not get fooled by servers that send abnormal long error
+				 * messages
+				 */
+
+				if (reasonBuffer.length() > 255)
+				{
+					reasonBuffer.setLength(255);
+					reasonBuffer.setCharAt(254, '.');
+					reasonBuffer.setCharAt(253, '.');
+					reasonBuffer.setCharAt(252, '.');
+				}
+
+				/*
+				 * Also, check that the server did not send charcaters that may
+				 * screw up the receiver -> restrict to reasonable US-ASCII
+				 * subset -> "printable characters" (ASCII 32 - 126). Replace
+				 * all others with 0xFFFD (UNICODE replacement character).
+				 */
+
+				for (int i = 0; i < reasonBuffer.length(); i++)
+				{
+					char c = reasonBuffer.charAt(i);
+
+					if ((c >= 32) && (c <= 126))
+						continue;
+					reasonBuffer.setCharAt(i, '\uFFFD');
+				}
+
+				throw new IOException("Peer sent DISCONNECT message (reason code " + reason_code + "): "
+						+ reasonBuffer.toString());
+			}
+
+			/*
+			 * Is it a KEX Packet?
+			 */
+
+			if ((type == Packets.SSH_MSG_KEXINIT) || (type == Packets.SSH_MSG_NEWKEYS)
+					|| ((type >= 30) && (type <= 49)))
+			{
+				km.handleMessage(msg, msglen);
+				continue;
+			}
+
+			MessageHandler mh = null;
+
+			for (int i = 0; i < messageHandlers.size(); i++)
+			{
+				HandlerEntry he = (HandlerEntry) messageHandlers.elementAt(i);
+				if ((he.low <= type) && (type <= he.high))
+				{
+					mh = he.mh;
+					break;
+				}
+			}
+
+			if (mh == null)
+				throw new IOException("Unexpected SSH message (type " + type + ")");
+
+			mh.handleMessage(msg, msglen);
+		}
+	}
+
+    /**
+     * Advertised maximum SSH packet size that the other side can send to us.
+     */
+    public static final int MAX_PACKET_SIZE = Integer.getInteger(
+    			TransportManager.class.getName()+".maxPacketSize",
+    			64*1024);
+}

--- a/src/com/trilead/ssh2/transport/TransportManagerNew.java
+++ b/src/com/trilead/ssh2/transport/TransportManagerNew.java
@@ -130,7 +130,7 @@ public class TransportManagerNew
 	Throwable reasonClosedCause = null;
 
 	TransportConnectionNew tc;
-	KexManager km;
+	KexManagerNew km;
 
 	Vector messageHandlers = new Vector();
 
@@ -473,7 +473,7 @@ public class TransportManagerNew
 
 		tc = new TransportConnectionNew(sock.getInputStream(), sock.getOutputStream(), rnd);
 
-		km = new KexManager(this, csh, cwl, hostname, port, verifier, rnd);
+		km = new KexManagerNew(this, csh, cwl, hostname, port, verifier, rnd);
 		km.initiateKEX(cwl, dhgex);
 
 		receiveThread = new Thread(new Runnable()
@@ -798,6 +798,6 @@ public class TransportManagerNew
      * Advertised maximum SSH packet size that the other side can send to us.
      */
     public static final int MAX_PACKET_SIZE = Integer.getInteger(
-    			TransportManager.class.getName()+".maxPacketSize",
+    			TransportManagerNew.class.getName()+".maxPacketSize",
     			64*1024);
 }


### PR DESCRIPTION
This also imports parts of https://github.com/connectbot/sshlib/ (Tag v2.2.0) to support kex algo sha256

This fixes https://issues.jenkins-ci.org/browse/JENKINS-33021 and https://issues.jenkins-ci.org/browse/JENKINS-36873 and https://issues.jenkins-ci.org/browse/JENKINS-31549

File MAC.java was done by @Elisedlund (Support for hmac 256) The updated kex algo was done from https://github.com/connectbot/sshlib/