### PR TITLE
[FIXED JENKINS-33021] Add support for SHA256 and SHA512 HMAC algorithms

### DIFF
--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -5,7 +5,7 @@ import com.trilead.ssh2.auth.AuthenticationManager;
 import com.trilead.ssh2.channel.ChannelManager;
 import com.trilead.ssh2.crypto.CryptoWishList;
 import com.trilead.ssh2.crypto.cipher.BlockCipherFactory;
-import com.trilead.ssh2.crypto.digest.MAC;
+import com.trilead.ssh2.crypto.digest.MessageMac;
 import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.PacketIgnore;
 import com.trilead.ssh2.transport.ClientServerHello;
@@ -75,7 +75,7 @@ public class Connection
 	 */
 	public static synchronized String[] getAvailableMACs()
 	{
-		return MAC.getMacList();
+		return MessageMac.getMacs();
 	}
 
 	/**
@@ -1242,7 +1242,7 @@ public class Connection
 		if ((macs == null) || (macs.length == 0))
 			throw new IllegalArgumentException();
 		macs = removeDuplicates(macs);
-		MAC.checkMacList(macs);
+		MessageMac.checkMacs(macs);
 		cryptoWishList.c2s_mac_algos = macs;
 	}
 
@@ -1288,7 +1288,7 @@ public class Connection
 			throw new IllegalArgumentException();
 
 		macs = removeDuplicates(macs);
-		MAC.checkMacList(macs);
+		MessageMac.checkMacs(macs);
 		cryptoWishList.s2c_mac_algos = macs;
 	}
 

--- a/src/com/trilead/ssh2/crypto/CryptoWishList.java
+++ b/src/com/trilead/ssh2/crypto/CryptoWishList.java
@@ -2,7 +2,7 @@
 package com.trilead.ssh2.crypto;
 
 import com.trilead.ssh2.crypto.cipher.BlockCipherFactory;
-import com.trilead.ssh2.crypto.digest.MAC;
+import com.trilead.ssh2.crypto.digest.MessageMac;
 import com.trilead.ssh2.transport.KexManager;
 
 
@@ -18,6 +18,6 @@ public class CryptoWishList
 	public String[] serverHostKeyAlgorithms = KexManager.getDefaultServerHostkeyAlgorithmList();
 	public String[] c2s_enc_algos = BlockCipherFactory.getDefaultCipherList();
 	public String[] s2c_enc_algos = BlockCipherFactory.getDefaultCipherList();
-	public String[] c2s_mac_algos = MAC.getMacList();
-	public String[] s2c_mac_algos = MAC.getMacList();
+	public String[] c2s_mac_algos = MessageMac.getMacs();
+	public String[] s2c_mac_algos = MessageMac.getMacs();
 }

--- a/src/com/trilead/ssh2/crypto/dh/DhExchange.java
+++ b/src/com/trilead/ssh2/crypto/dh/DhExchange.java
@@ -61,8 +61,17 @@ public class DhExchange
 		g = new BigInteger("2");
 	}
 
+	private final String hashAlgorithm;
+
+	@Deprecated
 	public DhExchange()
 	{
+		this("SHA1");
+	}
+
+	public DhExchange(String hashAlgorightm) {
+		super();
+		this.hashAlgorithm = hashAlgorightm;
 	}
 
 	public void init(int group, SecureRandom rnd)
@@ -125,7 +134,7 @@ public class DhExchange
 	public byte[] calculateH(byte[] clientversion, byte[] serverversion, byte[] clientKexPayload,
 			byte[] serverKexPayload, byte[] hostKey) throws UnsupportedEncodingException
 	{
-		HashForSSH2Types hash = new HashForSSH2Types("SHA1");
+		HashForSSH2Types hash = new HashForSSH2Types(getHashAlgorithm());
 
 		if (log.isEnabled())
 		{
@@ -143,5 +152,9 @@ public class DhExchange
 		hash.updateBigInt(k);
 
 		return hash.getDigest();
+	}
+
+	public String getHashAlgorithm() {
+		return hashAlgorithm;
 	}
 }

--- a/src/com/trilead/ssh2/crypto/dh/DhGroupExchange.java
+++ b/src/com/trilead/ssh2/crypto/dh/DhGroupExchange.java
@@ -34,10 +34,19 @@ public class DhGroupExchange
 
 	private BigInteger k;
 
-	public DhGroupExchange(BigInteger p, BigInteger g)
+	private final String hashAlgorithm;
+
+	@Deprecated
+	public DhGroupExchange(BigInteger p, BigInteger g) {
+		this("SHA1", p, g);
+	}
+
+
+	public DhGroupExchange(String algorithm, BigInteger p, BigInteger g)
 	{
 		this.p = p;
 		this.g = g;
+		this.hashAlgorithm = algorithm;
 	}
 
 	public void init(SecureRandom rnd)
@@ -90,7 +99,7 @@ public class DhGroupExchange
 	public byte[] calculateH(byte[] clientversion, byte[] serverversion, byte[] clientKexPayload,
 			byte[] serverKexPayload, byte[] hostKey, DHGexParameters para)
 	{
-		HashForSSH2Types hash = new HashForSSH2Types("SHA1");
+		HashForSSH2Types hash = new HashForSSH2Types(getHashAlgorithm());
 
 		hash.updateByteString(clientversion);
 		hash.updateByteString(serverversion);
@@ -109,5 +118,9 @@ public class DhGroupExchange
 		hash.updateBigInt(k);
 
 		return hash.getDigest();
+	}
+
+	public String getHashAlgorithm() {
+		return hashAlgorithm;
 	}
 }

--- a/src/com/trilead/ssh2/crypto/digest/HMAC.java
+++ b/src/com/trilead/ssh2/crypto/digest/HMAC.java
@@ -7,6 +7,7 @@ package com.trilead.ssh2.crypto.digest;
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: HMAC.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
  */
+@Deprecated
 public final class HMAC implements Digest
 {
 	Digest md;

--- a/src/com/trilead/ssh2/crypto/digest/HashForSSH2Types.java
+++ b/src/com/trilead/ssh2/crypto/digest/HashForSSH2Types.java
@@ -2,6 +2,8 @@
 package com.trilead.ssh2.crypto.digest;
 
 import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 
 /**
  * HashForSSH2Types.
@@ -11,25 +13,37 @@ import java.math.BigInteger;
  */
 public class HashForSSH2Types
 {
+
+	/**
+	 * Overwriting this value will not cause the result of the
+	 * digest to change
+	 * @deprecated the actual message digest is held in a private field
+	 */
+	@Deprecated
 	Digest md;
+	
+	private final Digest messageDigest;
+	
+	
 
 	public HashForSSH2Types(Digest md)
 	{
+		super();
 		this.md = md;
+		this.messageDigest = md;
 	}
 
 	public HashForSSH2Types(String type)
 	{
-		if (type.equals("SHA1"))
-		{
-			md = new SHA1();
+		this(new JreMessageDigestWrapper(createMessageDigest(type)));
+	}
+
+	private static MessageDigest createMessageDigest(String algorithm) {
+		try {
+			return MessageDigest.getInstance(algorithm);
+		} catch (GeneralSecurityException ex) {
+			throw new IllegalArgumentException("Could not get Message digest instance", ex);
 		}
-		else if (type.equals("MD5"))
-		{
-			md = new MD5();
-		}
-		else
-			throw new IllegalArgumentException("Unknown algorithm " + type);
 	}
 
 	public void updateByte(byte b)
@@ -37,20 +51,20 @@ public class HashForSSH2Types
 		/* HACK - to test it with J2ME */
 		byte[] tmp = new byte[1];
 		tmp[0] = b;
-		md.update(tmp);
+		messageDigest.update(tmp);
 	}
 
 	public void updateBytes(byte[] b)
 	{
-		md.update(b);
+		messageDigest.update(b);
 	}
 
 	public void updateUINT32(int v)
 	{
-		md.update((byte) (v >> 24));
-		md.update((byte) (v >> 16));
-		md.update((byte) (v >> 8));
-		md.update((byte) (v));
+		messageDigest.update((byte) (v >> 24));
+		messageDigest.update((byte) (v >> 16));
+		messageDigest.update((byte) (v >> 8));
+		messageDigest.update((byte) (v));
 	}
 
 	public void updateByteString(byte[] b)
@@ -66,17 +80,17 @@ public class HashForSSH2Types
 
 	public void reset()
 	{
-		md.reset();
+		messageDigest.reset();
 	}
 
 	public int getDigestLength()
 	{
-		return md.getDigestLength();
+		return messageDigest.getDigestLength();
 	}
 
 	public byte[] getDigest()
 	{
-		byte[] tmp = new byte[md.getDigestLength()];
+		byte[] tmp = new byte[messageDigest.getDigestLength()];
 		getDigest(tmp);
 		return tmp;
 	}
@@ -88,6 +102,6 @@ public class HashForSSH2Types
 
 	public void getDigest(byte[] out, int off)
 	{
-		md.digest(out, off);
+		messageDigest.digest(out, off);
 	}
 }

--- a/src/com/trilead/ssh2/crypto/digest/JreMessageDigestWrapper.java
+++ b/src/com/trilead/ssh2/crypto/digest/JreMessageDigestWrapper.java
@@ -1,0 +1,47 @@
+package com.trilead.ssh2.crypto.digest;
+
+import java.security.MessageDigest;
+
+/**
+ * @author Michael Clarke
+ */
+public class JreMessageDigestWrapper implements Digest {
+
+    private final MessageDigest digest;
+
+    public JreMessageDigestWrapper(MessageDigest digest) {
+        super();
+        this.digest = digest;
+    }
+
+    public int getDigestLength() {
+        return digest.getDigestLength();
+    }
+
+    public void update(byte b) {
+        digest.update(b);
+    }
+
+    public void update(byte[] b) {
+        digest.update(b);
+    }
+
+    public void update(byte[] b, int off, int len) {
+        digest.update(b, off, len);
+    }
+
+    public void reset() {
+        digest.reset();
+    }
+
+    public void digest(byte[] out) {
+        byte[] output = digest.digest();
+        System.arraycopy(output, 0, out, 0, out.length);
+    }
+
+    public void digest(byte[] out, int off) {
+        byte[] output = digest.digest();
+        System.arraycopy(output, 0, out, off, out.length);
+
+    }
+}

--- a/src/com/trilead/ssh2/crypto/digest/MAC.java
+++ b/src/com/trilead/ssh2/crypto/digest/MAC.java
@@ -2,30 +2,57 @@
 package com.trilead.ssh2.crypto.digest;
 
 /**
- * MAC.
+ * MAC. Replace by {@link MessageMac to support enchanced Mac algorithms}
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: MAC.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
  */
-public final class MAC
+/* This class is technically deprecated, but isn't marked as such since it's
+* just the implementation with the public fields that's deprecated, rather than
+* any of the methods in it
+*/
+public class MAC
 {
+	/**
+	 * @deprecated May be null if a newer Mac algorithm is used
+	 */
+	@Deprecated
 	Digest mac;
+
+	/**
+	 * @deprecated May be null if a newer Mac algorithm is used
+	 */
+	@Deprecated
 	int size;
 
-	public final static String[] getMacList()
+	/**
+	 * @deprecated Use {@link MessageMac#getMacs()}
+	 */
+	@Deprecated
+	public static String[] getMacList()
 	{
 		/* Higher Priority First */
 
 		return new String[] { "hmac-sha1-96", "hmac-sha1", "hmac-md5-96", "hmac-md5" };
 	}
 
-	public final static void checkMacList(String[] macs)
+
+	/**
+	 * @deprecated Use {@link MessageMac#checkMacs(String[])}
+	 */
+	@Deprecated
+	public static void checkMacList(String[] macs)
 	{
 		for (int i = 0; i < macs.length; i++)
 			getKeyLen(macs[i]);
 	}
 
-	public final static int getKeyLen(String type)
+
+	/**
+	 * @deprecated Use {@link MessageMac#getKeyLength(String)}
+	 */
+	@Deprecated
+	public static int getKeyLen(String type)
 	{
 		if (type.equals("hmac-sha1"))
 			return 20;
@@ -38,6 +65,11 @@ public final class MAC
 		throw new IllegalArgumentException("Unkown algorithm " + type);
 	}
 
+	/**
+	 * @param type the MAC algorithm to use
+	 * @param key the key to use in the MAC
+	 * @deprecated use {@link MessageMac#MessageMac(String, byte[])}
+	 */
 	public MAC(String type, byte[] key)
 	{
 		if (type.equals("hmac-sha1"))
@@ -57,12 +89,12 @@ public final class MAC
 			mac = new HMAC(new MD5(), key, 12);
 		}
 		else
-			throw new IllegalArgumentException("Unkown algorithm " + type);
+			return;
 
 		size = mac.getDigestLength();
 	}
 
-	public final void initMac(int seq)
+	public void initMac(int seq)
 	{
 		mac.reset();
 		mac.update((byte) (seq >> 24));
@@ -71,17 +103,17 @@ public final class MAC
 		mac.update((byte) (seq));
 	}
 
-	public final void update(byte[] packetdata, int off, int len)
+	public void update(byte[] packetdata, int off, int len)
 	{
 		mac.update(packetdata, off, len);
 	}
 
-	public final void getMac(byte[] out, int off)
+	public void getMac(byte[] out, int off)
 	{
 		mac.digest(out, off);
 	}
 
-	public final int size()
+	public int size()
 	{
 		return size;
 	}

--- a/src/com/trilead/ssh2/crypto/digest/MD5.java
+++ b/src/com/trilead/ssh2/crypto/digest/MD5.java
@@ -30,9 +30,9 @@ package com.trilead.ssh2.crypto.digest;
  * 
  * These notices must be retained in any copies of any part of this
  * documentation and/or software.
- * 
+ * @deprecated Use java.security.MessageDigest.getInstance("MD5");
  */
-
+@Deprecated
 public final class MD5 implements Digest
 {
 	private int state0, state1, state2, state3;

--- a/src/com/trilead/ssh2/crypto/digest/MessageMac.java
+++ b/src/com/trilead/ssh2/crypto/digest/MessageMac.java
@@ -1,0 +1,107 @@
+
+package com.trilead.ssh2.crypto.digest;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class MessageMac extends MAC {
+
+	private final Mac messageMac;
+
+	public MessageMac(String type, byte[] key) {
+		super(type, key);
+
+		try {
+			messageMac = Mac.getInstance(Hmac.getHmac(type).getAlgorithm());
+			messageMac.init(new SecretKeySpec(key, type));
+		} catch (GeneralSecurityException ex) {
+			throw new IllegalArgumentException("Could not create Mac", ex);
+		}
+	}
+
+
+	public static String[] getMacs() {
+		List<String> macList = new ArrayList<String>();
+		for (Hmac hmac : Hmac.values()) {
+			macList.add(0, hmac.getType());
+		}
+		return macList.toArray(new String[macList.size()]);
+	}
+
+	public static void checkMacs(String[] macs) {
+		for (String mac : macs) {
+			Hmac.getHmac(mac);
+		}
+	}
+
+	public static int getKeyLength(String type) {
+		return Hmac.getHmac(type).getLength();
+	}
+
+	public final void initMac(int seq) {
+		messageMac.reset();
+		messageMac.update((byte) (seq >> 24));
+		messageMac.update((byte) (seq >> 16));
+		messageMac.update((byte) (seq >> 8));
+		messageMac.update((byte) (seq));
+	}
+
+	public final void update(byte[] packetdata, int off, int len)
+	{
+		messageMac.update(packetdata, off, len);
+	}
+
+	public final void getMac(byte[] out, int off) {
+		byte[] mac = messageMac.doFinal();
+		System.arraycopy(mac, off, out, 0, mac.length - off);
+	}
+
+	public final int size()
+	{
+		return messageMac.getMacLength();
+	}
+
+
+	private enum Hmac {
+		HMAC_MD5_96("hmac-md5-96", "HmacMD5", 16),
+		HMAC_MD5("hmac-md5", "HmacMD5", 16),
+		HMAC_SHA1_96("hmac-sha1-96", "HmacSHA1", 20),
+		HMAC_SHA1("hmac-sha1", "HmacSHA1", 20),
+		HMAC_SHA2_256("hmac-sha2-256", "HmacSHA256", 32),
+		HMAC_SHA2_512("hmac-sha2-512", "HmacSHA512", 64);
+
+		private String type;
+		private String algorithm;
+		private int length;
+
+		Hmac(String type, String algorithm, int length) {
+			this.type = type;
+			this.algorithm = algorithm;
+			this.length = length;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public String getAlgorithm() {
+			return algorithm;
+		}
+
+		public int getLength() {
+			return length;
+		}
+
+		private static Hmac getHmac(String type) {
+			for (Hmac hmac : values()) {
+				if (hmac.getType().equals(type)) {
+					return hmac;
+				}
+			}
+			throw new IllegalArgumentException("Invalid HMAC type: " + type);
+		}
+	}
+}

--- a/src/com/trilead/ssh2/crypto/digest/SHA1.java
+++ b/src/com/trilead/ssh2/crypto/digest/SHA1.java
@@ -9,7 +9,9 @@ package com.trilead.ssh2.crypto.digest;
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: SHA1.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
+ * @deprecated Use java.security.MessageDigest.getInstance("SHA1");
  */
+@Deprecated
 public final class SHA1 implements Digest
 {
 	private int H0, H1, H2, H3, H4;
@@ -606,59 +608,4 @@ public final class SHA1 implements Digest
 		return sb.toString();
 	}
 
-	public static void main(String[] args)
-	{
-		SHA1 sha = new SHA1();
-
-		byte[] dig1 = new byte[20];
-		byte[] dig2 = new byte[20];
-		byte[] dig3 = new byte[20];
-
-		/*
-		 * We do not specify a charset name for getBytes(), since we assume that
-		 * the JVM's default encoder maps the _used_ ASCII characters exactly as
-		 * getBytes("US-ASCII") would do. (Ah, yes, too lazy to catch the
-		 * exception that can be thrown by getBytes("US-ASCII")). Note: This has
-		 * no effect on the SHA-1 implementation, this is just for the following
-		 * test code.
-		 */
-
-		sha.update("abc".getBytes());
-		sha.digest(dig1);
-
-		sha.update("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".getBytes());
-		sha.digest(dig2);
-
-		for (int i = 0; i < 1000000; i++)
-			sha.update((byte) 'a');
-		sha.digest(dig3);
-
-		String dig1_res = toHexString(dig1);
-		String dig2_res = toHexString(dig2);
-		String dig3_res = toHexString(dig3);
-
-		String dig1_ref = "A9993E364706816ABA3E25717850C26C9CD0D89D";
-		String dig2_ref = "84983E441C3BD26EBAAE4AA1F95129E5E54670F1";
-		String dig3_ref = "34AA973CD4C4DAA4F61EEB2BDBAD27316534016F";
-
-		if (dig1_res.equals(dig1_ref))
-			System.out.println("SHA-1 Test 1 OK.");
-		else
-			System.out.println("SHA-1 Test 1 FAILED.");
-
-		if (dig2_res.equals(dig2_ref))
-			System.out.println("SHA-1 Test 2 OK.");
-		else
-			System.out.println("SHA-1 Test 2 FAILED.");
-
-		if (dig3_res.equals(dig3_ref))
-			System.out.println("SHA-1 Test 3 OK.");
-		else
-			System.out.println("SHA-1 Test 3 FAILED.");
-
-		if (dig3_res.equals(dig3_ref))
-			System.out.println("SHA-1 Test 3 OK.");
-		else
-			System.out.println("SHA-1 Test 3 FAILED.");
-	}
 }

--- a/src/com/trilead/ssh2/transport/KexState.java
+++ b/src/com/trilead/ssh2/transport/KexState.java
@@ -29,4 +29,13 @@ public class KexState
 	public DhExchange dhx;
 	public DhGroupExchange dhgx;
 	public DHGexParameters dhgexParameters;
+	private String hashAlgorithm;
+
+    public void setHashAlgorithm(String hashAlgorithm) {
+        this.hashAlgorithm = hashAlgorithm;
+    }
+
+    public String getHashAlgorithm() {
+    	return hashAlgorithm;
+	}
 }


### PR DESCRIPTION
An alternative to #9 and #7  that reduces the number of classes under change and doesn't break binary compatibility.