### PR TITLE
Disable eddsa temporarily

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,13 @@
       <version>4.10</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
+    <!-- disable this temporarily and re enable when sshd 1.5.0 is released
+    this would have conflicted in jenkins core-->
+    <!--<dependency>
       <groupId>net.i2p.crypto</groupId>
       <artifactId>eddsa</artifactId>
       <version>0.2.0</version>
-    </dependency>
+    </dependency>-->
     <dependency>
       <groupId>org.connectbot.jbcrypt</groupId>
       <artifactId>jbcrypt</artifactId>


### PR DESCRIPTION
We can re do this once sshd 1.5.0 is released. This is to allow us to unbreak https://github.com/jenkinsci/jenkins/pull/2853 and be able to merge both the trilead upgrade and sshd upgrade :)