### PR TITLE
[JENKINS-43979] Fix OpenSSH dropping connections with SHA512 enabled

### DIFF
--- a/src/com/trilead/ssh2/DHGexParameters.java
+++ b/src/com/trilead/ssh2/DHGexParameters.java
@@ -24,13 +24,13 @@ public class DHGexParameters
 	private static final int MAX_ALLOWED = 8192;
 
 	/**
-	 * Same as calling {@link #DHGexParameters(int, int, int) DHGexParameters(1024, 1024, 4096)}.
+	 * Same as calling {@link #DHGexParameters(int, int, int) DHGexParameters(1024, 2048, 4096)}.
 	 * This is also the default used by the Connection class.
 	 * 
 	 */
 	public DHGexParameters()
 	{
-		this(1024, 1024, 4096);
+		this(1024, 2048, 4096);
 	}
 
 	/**


### PR DESCRIPTION
Older versions of OpenSSH (verified against OpenSSH_5.9) do not correctly expand the key so drop the connection with a message similar to `fatal: dh_gen_key: group too small: 1024 (2*need 1024) [preauth]`. This change forces Trilead to generate a key at least 2048 bits in length to overcome this key expansion issue.