### PR TITLE
[JENKINS-42959] Correctly check host key algorithm

### DIFF
--- a/src/com/trilead/ssh2/KnownHosts.java
+++ b/src/com/trilead/ssh2/KnownHosts.java
@@ -599,7 +599,7 @@ public class KnownHosts
 
 	private PublicKey decodeHostKey(String hostKeyAlgorithm, byte[] encodedHostKey) throws IOException {
 		for (KeyAlgorithm<PublicKey, PrivateKey> algorithm : KeyAlgorithmManager.getSupportedAlgorithms()) {
-			if (algorithm.getKeyFormat().equals(encodedHostKey)) {
+			if (algorithm.getKeyFormat().equals(hostKeyAlgorithm)) {
 				return algorithm.decodePublicKey(encodedHostKey);
 			}
 		}

--- a/test/com/trilead/ssh2/KnownHostsTest.java
+++ b/test/com/trilead/ssh2/KnownHostsTest.java
@@ -14,6 +14,7 @@ import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 /**
@@ -67,6 +68,19 @@ public class KnownHostsTest {
         KeyPairGenerator rsaGenerator = KeyPairGenerator.getInstance("RSA");
         testCase.addHostkey(new String[]{"localhost"}, "ssh-rsa", new RSAKeyAlgorithm().encodePublicKey((RSAPublicKey) rsaGenerator.generateKeyPair().getPublic()));
         assertNull(testCase.getPreferredServerHostkeyAlgorithmOrder("localhost"));
+    }
+
+
+    @Test
+    public void testVerifyKnownHostKey() throws IOException, NoSuchAlgorithmException {
+        KnownHosts testCase = new KnownHosts();
+        KeyPairGenerator rsaGenerator = KeyPairGenerator.getInstance("RSA");
+        byte[] encodedPublicKey = new RSAKeyAlgorithm().encodePublicKey((RSAPublicKey) rsaGenerator.generateKeyPair().getPublic());
+        byte[] encodedPublicKey2 = new RSAKeyAlgorithm().encodePublicKey((RSAPublicKey) rsaGenerator.generateKeyPair().getPublic());
+        testCase.addHostkey(new String[]{"testhost"}, "ssh-rsa", encodedPublicKey);
+        assertEquals(KnownHosts.HOSTKEY_IS_NEW, testCase.verifyHostkey("testhost2", "ssh-rsa", encodedPublicKey));
+        assertEquals(KnownHosts.HOSTKEY_HAS_CHANGED, testCase.verifyHostkey("testhost", "ssh-rsa", encodedPublicKey2));
+        assertEquals(KnownHosts.HOSTKEY_IS_OK, testCase.verifyHostkey("testhost", "ssh-rsa", encodedPublicKey));
     }
 
 }


### PR DESCRIPTION
The known hosts key check is currently comparing the wrong fields whilst trying to find an algorithm to parse the current key - it should be checking the key format but is checking the key contents. This change fixes the comparison and adds a test to prevent future regression.

@paladox and @jenkinsci/code-reviewers