### PR TITLE
[JENKINS-44120] Prevent NPE when using DH group 1 or 14 with SHA1 KEX

### DIFF
--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -444,7 +444,7 @@ public class KexManager implements MessageHandler
 			if (kxs.np.kex_algo.equals("diffie-hellman-group1-sha1")
 					|| kxs.np.kex_algo.equals("diffie-hellman-group14-sha1"))
 			{
-				kxs.dhx = new DhExchange(kxs.dhx.getHashAlgorithm());
+				kxs.dhx = new DhExchange("SHA1");
 
 				if (kxs.np.kex_algo.equals("diffie-hellman-group1-sha1"))
 					kxs.dhx.init(1, rnd);


### PR DESCRIPTION
Trilead currently tries to read a sub-field of the field it's trying to set whilst creating the Key Exchange Parameters for diffie-hellman-group1-sha1 and diffie-hellman-group14-sha1. This causes a NullPointerException as the field being read can only ever by null at this point. This PR modifies Trilead to use a hardcoded reference to `SHA1` at this point since the algorithm can only ever be using SHA1 in this scenario.