### PR TITLE
[JENKINS-47458] - Check for null in Connection#getReasonClosedCause()

### DIFF
--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -1553,7 +1553,7 @@ public class Connection
      * return a non-null object indicating the cause of the connection loss.
      */
     public Throwable getReasonClosedCause() {
-        return tm.getReasonClosedCause();
+        return tm != null ? tm.getReasonClosedCause() : null;
     }
 
     /**


### PR DESCRIPTION
Just caught it in SSH Slaves plugin tests on my local machine: https://issues.jenkins-ci.org/browse/JENKINS-47458

Not sure whether `null` is valid though

@reviewbybees @paladox @mc1arke 