### PR TITLE
[JENKINS-47603] Just print the SCP response code under failure

### DIFF
--- a/src/com/trilead/ssh2/SCPClient.java
+++ b/src/com/trilead/ssh2/SCPClient.java
@@ -43,11 +43,15 @@ public class SCPClient
 	{
 		int c = is.read();
 
-		if (c == 0) {
+		if (c == 0)
 			return;
-		} else {
-			throw new IOException("Remote scp terminated with error code " + c);
+
+		if (c == 1) {
+			String err = receiveLine(is);
+			throw new IOException("Remote scp terminated with error (" + err + ").");
 		}
+
+		throw new IOException("Remote scp terminated with error code " + c);
 	}
 
 	private String receiveLine(InputStream is) throws IOException

--- a/src/com/trilead/ssh2/SCPClient.java
+++ b/src/com/trilead/ssh2/SCPClient.java
@@ -43,20 +43,11 @@ public class SCPClient
 	{
 		int c = is.read();
 
-		if (c == 0)
+		if (c == 0) {
 			return;
-
-		if (c == -1)
-			throw new IOException("Remote scp terminated unexpectedly.");
-
-		if ((c != 1) && (c != 2))
-			throw new IOException("Remote scp sent illegal error code.");
-
-		if (c == 2)
-			throw new IOException("Remote scp terminated with error.");
-
-		String err = receiveLine(is);
-		throw new IOException("Remote scp terminated with error (" + err + ").");
+		} else {
+			throw new IOException("Remote scp terminated with error code " + c);
+		}
 	}
 
 	private String receiveLine(InputStream is) throws IOException


### PR DESCRIPTION
`SCP` does not seem to have an RFC which generalized for the responses error code, so it seems to depend on each implementation. In any case, `0` seems to mean always operations successful, but the old code does not tell you the error response code in case of failure. 

I don't know too much about `trilead-ssh2`, so the simplification I am doing might be totally wrong.

The goal is to print the error response code under any failure.

A review is appreciated.


```
Oct 13, 2017 3:51:57 PM null 
INFO: Copying slave.jar 
ERROR: Error during SCP transfer. 
java.io.IOException: Error during SCP transfer. 
at com.trilead.ssh2.SCPClient.put(SCPClient.java:523) 
at com.trilead.ssh2.SCPClient.put(SCPClient.java:476) 
at hudson.plugins.ec2.ssh.EC2UnixLauncher.launch(EC2UnixLauncher.java:214) 
at hudson.plugins.ec2.EC2ComputerLauncher.launch(EC2ComputerLauncher.java:122) 
at hudson.slaves.SlaveComputer$1.call(SlaveComputer.java:262) 
at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46) 
at java.util.concurrent.FutureTask.run(FutureTask.java:266) 
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) 
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) 
at java.lang.Thread.run(Thread.java:748) 
Caused by: java.io.IOException: Remote scp sent illegal error code. 
at com.trilead.ssh2.SCPClient.readResponse(SCPClient.java:53) 
at com.trilead.ssh2.SCPClient.sendBytes(SCPClient.java:140) 
at com.trilead.ssh2.SCPClient.put(SCPClient.java:519) 
... 9 more
```

* https://issues.jenkins-ci.org/browse/JENKINS-47603

@reviewbybees CC myself @fbelzunc - to get email notification.