### PR TITLE
Support for port=0 which means automatically allocated port.

### DIFF
--- a/src/com/trilead/ssh2/LocalPortForwarder.java
+++ b/src/com/trilead/ssh2/LocalPortForwarder.java
@@ -60,4 +60,10 @@ public class LocalPortForwarder
 	{
 		lat.stopWorking();
 	}
+	
+    public int getLocalPort() 
+    {
+        return lat.getLocalPort();
+    }
+	
 }

--- a/src/com/trilead/ssh2/channel/LocalAcceptThread.java
+++ b/src/com/trilead/ssh2/channel/LocalAcceptThread.java
@@ -132,4 +132,9 @@ public class LocalAcceptThread extends Thread implements IChannelWorkerThread
 		{
 		}
 	}
+	
+	public int getLocalPort() 
+	{
+		return ss.getLocalPort();
+	}
 }


### PR DESCRIPTION
typically allocated from an ephemeral port range

java.net.ServerSocket has support for setting port to 0 and will then
automatically allocate a port.
trilead.LocalPortForwarder handles port 0 fine already however as a end
user its currently not possible to figure out which port was actually
allocated in the end which this fix changes.