### PR TITLE
[JENKINS-62552] Use standard crypto APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/com/trilead/ssh2/crypto/cipher/AES.java
+++ b/src/com/trilead/ssh2/crypto/cipher/AES.java
@@ -57,6 +57,8 @@ package com.trilead.ssh2.crypto.cipher;
  * 
  * @author See comments in the source file
  * @version $Id: AES.java,v 1.1 2007/10/15 12:49:55 cplattne Exp $
+ * @deprecated Use {@link javax.crypto.Cipher} instead.
+ * See <a href="https://issues.jenkins-ci.org/browse/JENKINS-62552">JENKINS-62552</a>.
  */
 public class AES implements BlockCipher
 {

--- a/src/com/trilead/ssh2/crypto/cipher/BlockCipherFactory.java
+++ b/src/com/trilead/ssh2/crypto/cipher/BlockCipherFactory.java
@@ -1,6 +1,7 @@
 
 package com.trilead.ssh2.crypto.cipher;
 
+import javax.crypto.spec.IvParameterSpec;
 import java.util.Vector;
 
 /**
@@ -14,46 +15,46 @@ public class BlockCipherFactory
 	static class CipherEntry
 	{
 		String type;
+		String algorithm;
 		int blocksize;
 		int keysize;
-		String cipherClass;
 
-		public CipherEntry(String type, int blockSize, int keySize, String cipherClass)
+		public CipherEntry(String type, String algorithm, int blockSize, int keySize)
 		{
 			this.type = type;
+			this.algorithm = algorithm;
 			this.blocksize = blockSize;
 			this.keysize = keySize;
-			this.cipherClass = cipherClass;
 		}
 	}
 
-	static Vector ciphers = new Vector();
+	static Vector<CipherEntry> ciphers = new Vector<>();
 
 	static
 	{
 		/* Higher Priority First */
 
-		ciphers.addElement(new CipherEntry("aes256-ctr", 16, 32, "com.trilead.ssh2.crypto.cipher.AES"));
-		ciphers.addElement(new CipherEntry("aes192-ctr", 16, 24, "com.trilead.ssh2.crypto.cipher.AES"));
-		ciphers.addElement(new CipherEntry("aes128-ctr", 16, 16, "com.trilead.ssh2.crypto.cipher.AES"));
-		ciphers.addElement(new CipherEntry("blowfish-ctr", 8, 16, "com.trilead.ssh2.crypto.cipher.BlowFish"));
+		ciphers.addElement(new CipherEntry("aes256-ctr", "AES/CTR/NoPadding", 16, 32));
+		ciphers.addElement(new CipherEntry("aes192-ctr", "AES/CTR/NoPadding", 16, 24));
+		ciphers.addElement(new CipherEntry("aes128-ctr", "AES/CTR/NoPadding", 16, 16));
+		ciphers.addElement(new CipherEntry("blowfish-ctr", "Blowfish/CTR/NoPadding", 8, 16));
 
-		ciphers.addElement(new CipherEntry("aes256-cbc", 16, 32, "com.trilead.ssh2.crypto.cipher.AES"));
-		ciphers.addElement(new CipherEntry("aes192-cbc", 16, 24, "com.trilead.ssh2.crypto.cipher.AES"));
-		ciphers.addElement(new CipherEntry("aes128-cbc", 16, 16, "com.trilead.ssh2.crypto.cipher.AES"));
-		ciphers.addElement(new CipherEntry("blowfish-cbc", 8, 16, "com.trilead.ssh2.crypto.cipher.BlowFish"));
+		ciphers.addElement(new CipherEntry("aes256-cbc", "AES/CBC/NoPadding", 16, 32));
+		ciphers.addElement(new CipherEntry("aes192-cbc", "AES/CBC/NoPadding", 16, 24));
+		ciphers.addElement(new CipherEntry("aes128-cbc", "AES/CBC/NoPadding", 16, 16));
+		ciphers.addElement(new CipherEntry("blowfish-cbc", "Blowfish/CBC/NoPadding", 8, 16));
 		
-		ciphers.addElement(new CipherEntry("3des-ctr", 8, 24, "com.trilead.ssh2.crypto.cipher.DESede"));
-		ciphers.addElement(new CipherEntry("3des-cbc", 8, 24, "com.trilead.ssh2.crypto.cipher.DESede"));
+		ciphers.addElement(new CipherEntry("3des-ctr", "DESede/CTR/NoPadding", 8, 24));
+		ciphers.addElement(new CipherEntry("3des-cbc", "DESede/CBC/NoPadding", 8, 24));
 	}
 
 	public static String[] getDefaultCipherList()
 	{
-		String list[] = new String[ciphers.size()];
+		String[] list = new String[ciphers.size()];
 		for (int i = 0; i < ciphers.size(); i++)
 		{
-			CipherEntry ce = (CipherEntry) ciphers.elementAt(i);
-			list[i] = new String(ce.type);
+			CipherEntry ce = ciphers.elementAt(i);
+			list[i] = ce.type;
 		}
 		return list;
 	}
@@ -66,35 +67,17 @@ public class BlockCipherFactory
 
 	public static BlockCipher createCipher(String type, boolean encrypt, byte[] key, byte[] iv)
 	{
-		try
-		{
-			CipherEntry ce = getEntry(type);
-			Class cc = Class.forName(ce.cipherClass);
-			BlockCipher bc = (BlockCipher) cc.newInstance();
-
-			if (type.endsWith("-cbc"))
-			{
-				bc.init(encrypt, key);
-				return new CBCMode(bc, iv, encrypt);
-			}
-			else if (type.endsWith("-ctr"))
-			{
-				bc.init(true, key);
-				return new CTRMode(bc, iv, encrypt);
-			}
-			throw new IllegalArgumentException("Cannot instantiate " + type);
-		}
-		catch (Exception e)
-		{
-			throw new IllegalArgumentException("Cannot instantiate " + type);
-		}
+		CipherEntry ce = getEntry(type);
+		BlockCipher bc = JreCipherWrapper.getInstance(ce.algorithm, new IvParameterSpec(iv));
+		bc.init(encrypt, key);
+		return bc;
 	}
 
 	private static CipherEntry getEntry(String type)
 	{
 		for (int i = 0; i < ciphers.size(); i++)
 		{
-			CipherEntry ce = (CipherEntry) ciphers.elementAt(i);
+			CipherEntry ce = ciphers.elementAt(i);
 			if (ce.type.equals(type))
 				return ce;
 		}

--- a/src/com/trilead/ssh2/crypto/cipher/BlowFish.java
+++ b/src/com/trilead/ssh2/crypto/cipher/BlowFish.java
@@ -34,6 +34,8 @@ package com.trilead.ssh2.crypto.cipher;
  * 
  * @author See comments in the source file
  * @version $Id: BlowFish.java,v 1.1 2007/10/15 12:49:55 cplattne Exp $
+ * @deprecated Use {@link javax.crypto.Cipher} instead.
+ * See <a href="https://issues.jenkins-ci.org/browse/JENKINS-62552">JENKINS-62552</a>.
  */
 public class BlowFish implements BlockCipher
 {

--- a/src/com/trilead/ssh2/crypto/cipher/CBCMode.java
+++ b/src/com/trilead/ssh2/crypto/cipher/CBCMode.java
@@ -5,6 +5,8 @@ package com.trilead.ssh2.crypto.cipher;
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: CBCMode.java,v 1.1 2007/10/15 12:49:55 cplattne Exp $
+ * @deprecated Use {@link javax.crypto.Cipher} with the {@code CBC} transformation mode instead.
+ * See <a href="https://issues.jenkins-ci.org/browse/JENKINS-62552">JENKINS-62552</a>.
  */
 public class CBCMode implements BlockCipher
 {

--- a/src/com/trilead/ssh2/crypto/cipher/CTRMode.java
+++ b/src/com/trilead/ssh2/crypto/cipher/CTRMode.java
@@ -6,6 +6,8 @@ package com.trilead.ssh2.crypto.cipher;
  * 
  * @author Christian Plattner, plattner@trilead.com
  * @version $Id: CTRMode.java,v 1.1 2007/10/15 12:49:55 cplattne Exp $
+ * @deprecated Use {@link javax.crypto.Cipher} with the {@code CTR} transformation mode instead.
+ * See <a href="https://issues.jenkins-ci.org/browse/JENKINS-62552">JENKINS-62552</a>.
  */
 public class CTRMode implements BlockCipher
 {

--- a/src/com/trilead/ssh2/crypto/cipher/DES.java
+++ b/src/com/trilead/ssh2/crypto/cipher/DES.java
@@ -32,7 +32,8 @@ package com.trilead.ssh2.crypto.cipher;
  * 
  * @author See comments in the source file
  * @version $Id: DES.java,v 1.1 2007/10/15 12:49:55 cplattne Exp $
- * 
+ * @deprecated Nobody should still be using DES for encryption. Use {@link javax.crypto.Cipher} instead for decryption.
+ * See <a href="https://issues.jenkins-ci.org/browse/JENKINS-62552">JENKINS-62552</a>.
  */
 public class DES implements BlockCipher
 {

--- a/src/com/trilead/ssh2/crypto/cipher/DESede.java
+++ b/src/com/trilead/ssh2/crypto/cipher/DESede.java
@@ -32,7 +32,8 @@ package com.trilead.ssh2.crypto.cipher;
  * 
  * @author See comments in the source file
  * @version $Id: DESede.java,v 1.1 2007/10/15 12:49:55 cplattne Exp $
- * 
+ * @deprecated Use {@link javax.crypto.Cipher} instead.
+ * See <a href="https://issues.jenkins-ci.org/browse/JENKINS-62552">JENKINS-62552</a>.
  */
 public class DESede extends DES
 {

--- a/src/com/trilead/ssh2/crypto/cipher/JreCipherWrapper.java
+++ b/src/com/trilead/ssh2/crypto/cipher/JreCipherWrapper.java
@@ -1,0 +1,75 @@
+package com.trilead.ssh2.crypto.cipher;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+
+/**
+ * BlockCipher that delegates cryptographic operations to {@code javax.crypt.Cipher}.
+ */
+public class JreCipherWrapper implements BlockCipher {
+
+    public static JreCipherWrapper getInstance(String algorithm, AlgorithmParameterSpec parameterSpec) {
+        try {
+            Cipher cipher = Cipher.getInstance(algorithm);
+            return new JreCipherWrapper(cipher, parameterSpec);
+        } catch (NoSuchPaddingException | NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private final Cipher cipher;
+    private final String algorithm;
+    private final AlgorithmParameterSpec parameterSpec;
+
+    private JreCipherWrapper(Cipher cipher, AlgorithmParameterSpec parameterSpec) {
+        this.cipher = cipher;
+        this.parameterSpec = parameterSpec;
+        String alg = cipher.getAlgorithm();
+        this.algorithm = alg.contains("/") ? alg.substring(0, alg.indexOf('/')) : alg;
+    }
+
+    @Override
+    public void init(boolean forEncryption, byte[] key) {
+        int mode = forEncryption ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE;
+        try {
+            cipher.init(mode, new SecretKeySpec(key, algorithm), parameterSpec);
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public void init(boolean forEncryption, KeySpec keySpec)  {
+        int mode = forEncryption ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE;
+        try {
+            SecretKeyFactory factory = SecretKeyFactory.getInstance(algorithm);
+            SecretKey key = factory.generateSecret(keySpec);
+            cipher.init(mode, key, parameterSpec);
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public int getBlockSize() {
+        return cipher.getBlockSize();
+    }
+
+    @Override
+    public void transformBlock(byte[] src, int srcoff, byte[] dst, int dstoff) {
+        try {
+            cipher.update(src, srcoff, cipher.getBlockSize(), dst, dstoff);
+        } catch (ShortBufferException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/src/com/trilead/ssh2/signature/OpenSshCertificateDecoder.java
+++ b/src/com/trilead/ssh2/signature/OpenSshCertificateDecoder.java
@@ -4,14 +4,17 @@ import com.trilead.ssh2.crypto.CertificateDecoder;
 import com.trilead.ssh2.crypto.PEMStructure;
 import com.trilead.ssh2.crypto.cipher.BlockCipher;
 import com.trilead.ssh2.crypto.cipher.BlockCipherFactory;
-import com.trilead.ssh2.crypto.cipher.CBCMode;
-import com.trilead.ssh2.crypto.cipher.DES;
+import com.trilead.ssh2.crypto.cipher.JreCipherWrapper;
 import com.trilead.ssh2.packets.TypesReader;
 import org.mindrot.jbcrypt.BCrypt;
 
+import javax.crypto.spec.DESKeySpec;
+import javax.crypto.spec.DESedeKeySpec;
+import javax.crypto.spec.IvParameterSpec;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
 import java.security.KeyPair;
 
 /**
@@ -141,15 +144,25 @@ abstract class OpenSshCertificateDecoder extends CertificateDecoder {
         DESEDE_CBC(24, 8, "des-ede3-cbc") {
             @Override
             BlockCipher createBlockCipher(byte[] key, byte[] iv, boolean encrypt) {
-                return BlockCipherFactory.createCipher("3des-cbc", encrypt, key, iv);
+                JreCipherWrapper bc = JreCipherWrapper.getInstance("DESede/CBC/NoPadding", new IvParameterSpec(iv));
+                try {
+                    bc.init(encrypt, new DESedeKeySpec(key));
+                } catch (InvalidKeyException e) {
+                    throw new IllegalArgumentException(e);
+                }
+                return bc;
             }
         },
         DES_CBC(8, 8, "des-cbc") {
             @Override
             BlockCipher createBlockCipher(byte[] key, byte[] iv, boolean encrypt) {
-                DES des = new DES();
-                des.init(encrypt, key);
-                return new CBCMode(des, iv, encrypt);
+                JreCipherWrapper bc = JreCipherWrapper.getInstance("DES/CBC/NoPadding", new IvParameterSpec(iv));
+                try {
+                    bc.init(encrypt, new DESKeySpec(key));
+                } catch (InvalidKeyException e) {
+                    throw new IllegalArgumentException(e);
+                }
+                return bc;
             }
         },
         AES128_CBC(16, 16, "aes-128-cbc", "aes128-cbc") {

--- a/test/com/trilead/ssh2/crypto/cipher/JreCipherWrapperTest.java
+++ b/test/com/trilead/ssh2/crypto/cipher/JreCipherWrapperTest.java
@@ -1,0 +1,52 @@
+package com.trilead.ssh2.crypto.cipher;
+
+import org.junit.Test;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class JreCipherWrapperTest {
+    @Test
+    public void shouldMatchJreBehavior() throws Exception {
+        SecureRandom rng = SecureRandom.getInstanceStrong();
+        byte[] iv = new byte[16];
+        rng.nextBytes(iv);
+        byte[] key = new byte[16];
+        rng.nextBytes(key);
+        JreCipherWrapper cipher = JreCipherWrapper.getInstance("AES/CTR/NoPadding", new IvParameterSpec(iv));
+        assertEquals(16, cipher.getBlockSize());
+        cipher.init(true, key);
+        byte[] plaintext = new byte[256];
+        rng.nextBytes(plaintext);
+        byte[] ciphertext = new byte[plaintext.length];
+        for (int i = 0; i < plaintext.length; i += cipher.getBlockSize()) {
+            cipher.transformBlock(plaintext, i, ciphertext, i);
+        }
+
+        Cipher jreCipher = Cipher.getInstance("AES/CTR/NoPadding");
+        jreCipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+        byte[] decrypted = jreCipher.doFinal(ciphertext);
+        assertArrayEquals(plaintext, decrypted);
+
+        // now the reverse
+        rng.nextBytes(iv);
+        rng.nextBytes(key);
+        rng.nextBytes(plaintext);
+        jreCipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+        ciphertext = jreCipher.doFinal(plaintext);
+
+        cipher = JreCipherWrapper.getInstance("AES/CTR/NoPadding", new IvParameterSpec(iv));
+        cipher.init(false, key);
+        Arrays.fill(decrypted, (byte) 0);
+        for (int i = 0; i < plaintext.length; i += cipher.getBlockSize()) {
+            cipher.transformBlock(ciphertext, i, decrypted, i);
+        }
+        assertArrayEquals(plaintext, decrypted);
+    }
+}


### PR DESCRIPTION
This deprecates the included implementations of block ciphers in preference of the ones bundled with the JDK.

Signed-off-by: Matt Sicker <boards@gmail.com>

@jeffret-b @daniel-beck @Wadeck 