### PR TITLE
[JENKINS-62311] Add support for RFC 8332

### DIFF
--- a/src/com/trilead/ssh2/signature/KeyAlgorithmManager.java
+++ b/src/com/trilead/ssh2/signature/KeyAlgorithmManager.java
@@ -38,7 +38,10 @@ public final class KeyAlgorithmManager {
             // we don't use ECDSA algorithms in this case
         }
 
-
+        // https://tools.ietf.org/html/rfc8332
+        algorithms.add(new RSAKeyAlgorithm("SHA256withRSA", "rsa-sha2-256"));
+        algorithms.add(new RSAKeyAlgorithm("SHA512withRSA", "rsa-sha2-512"));
+        // TODO: remove SHA-1 support soon
         algorithms.add(new RSAKeyAlgorithm());
         algorithms.add(new DSAKeyAlgorithm());
 

--- a/src/com/trilead/ssh2/signature/RSAKeyAlgorithm.java
+++ b/src/com/trilead/ssh2/signature/RSAKeyAlgorithm.java
@@ -27,8 +27,15 @@ import java.util.List;
  */
 public class RSAKeyAlgorithm extends KeyAlgorithm<RSAPublicKey, RSAPrivateKey> {
 
+    private static final String SSH_RSA = "ssh-rsa";
+
     public RSAKeyAlgorithm() {
-        super("SHA1WithRSA", "ssh-rsa", RSAPrivateKey.class);
+        this("SHA1WithRSA", SSH_RSA);
+    }
+
+    // https://tools.ietf.org/html/rfc8332
+    public RSAKeyAlgorithm(String signatureAlgorithm, String keyFormat) {
+        super(signatureAlgorithm, keyFormat, RSAPrivateKey.class);
     }
 
     @Override
@@ -86,7 +93,7 @@ public class RSAKeyAlgorithm extends KeyAlgorithm<RSAPublicKey, RSAPrivateKey> {
     public byte[] encodePublicKey(RSAPublicKey publicKey) throws IOException {
         final TypesWriter tw = new TypesWriter();
 
-        tw.writeString(getKeyFormat());
+        tw.writeString(SSH_RSA);
         tw.writeMPInt(publicKey.getPublicExponent());
         tw.writeMPInt(publicKey.getModulus());
 
@@ -98,7 +105,7 @@ public class RSAKeyAlgorithm extends KeyAlgorithm<RSAPublicKey, RSAPrivateKey> {
         final TypesReader tr = new TypesReader(encodedPublicKey);
 
         final String key_format = tr.readString();
-        if (!key_format.equals(getKeyFormat())) {
+        if (!key_format.equals(SSH_RSA)) {
             throw new IOWarningException("Unsupported key format found '" + key_format + "' while expecting " + getKeyFormat());
         }
 
@@ -119,7 +126,7 @@ public class RSAKeyAlgorithm extends KeyAlgorithm<RSAPublicKey, RSAPrivateKey> {
 
     @Override
     public List<CertificateDecoder> getCertificateDecoders() {
-        return Arrays.asList(new RSACertificateDecoder(), new OpenSshCertificateDecoder("ssh-rsa") {
+        return Arrays.asList(new RSACertificateDecoder(), new OpenSshCertificateDecoder(SSH_RSA) {
             @Override
             KeyPair generateKeyPair(TypesReader typesReader) throws GeneralSecurityException, IOException {
                 BigInteger n = typesReader.readMPINT();

--- a/test/com/trilead/ssh2/KnownHostsTest.java
+++ b/test/com/trilead/ssh2/KnownHostsTest.java
@@ -27,7 +27,7 @@ public class KnownHostsTest {
         KnownHosts testCase = new KnownHosts();
         KeyPairGenerator dsaGenerator = KeyPairGenerator.getInstance("DSA");
         testCase.addHostkey(new String[]{"localhost"}, "ssh-dss", new DSAKeyAlgorithm().encodePublicKey((DSAPublicKey) dsaGenerator.generateKeyPair().getPublic()));
-        assertArrayEquals(new String[]{"ssh-dss", "ssh-ed25519", "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp256", "ssh-rsa"}, testCase.getPreferredServerHostkeyAlgorithmOrder("localhost"));
+        assertArrayEquals(new String[]{"ssh-dss", "ssh-ed25519", "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp256", "rsa-sha2-256", "rsa-sha2-512", "ssh-rsa"}, testCase.getPreferredServerHostkeyAlgorithmOrder("localhost"));
     }
 
     @Test
@@ -35,7 +35,7 @@ public class KnownHostsTest {
         KnownHosts testCase = new KnownHosts();
         KeyPairGenerator rsaGenerator = KeyPairGenerator.getInstance("RSA");
         testCase.addHostkey(new String[]{"localhost"}, "ssh-rsa", new RSAKeyAlgorithm().encodePublicKey((RSAPublicKey) rsaGenerator.generateKeyPair().getPublic()));
-        assertArrayEquals(new String[]{"ssh-rsa", "ssh-ed25519", "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp256", "ssh-dss"}, testCase.getPreferredServerHostkeyAlgorithmOrder("localhost"));
+        assertArrayEquals(new String[]{"ssh-rsa", "ssh-ed25519", "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp256", "rsa-sha2-256", "rsa-sha2-512", "ssh-dss"}, testCase.getPreferredServerHostkeyAlgorithmOrder("localhost"));
     }
 
 
@@ -44,7 +44,7 @@ public class KnownHostsTest {
         KnownHosts testCase = new KnownHosts();
         KeyPairGenerator ecGenerator = KeyPairGenerator.getInstance("EC");
         testCase.addHostkey(new String[]{"localhost"}, "ecdsa-sha2-nistp256", new ECDSAKeyAlgorithm.ECDSASha2Nistp256().encodePublicKey((ECPublicKey) ecGenerator.generateKeyPair().getPublic()));
-        assertArrayEquals(new String[]{"ecdsa-sha2-nistp256", "ssh-ed25519", "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp384", "ssh-rsa", "ssh-dss"}, testCase.getPreferredServerHostkeyAlgorithmOrder("localhost"));
+        assertArrayEquals(new String[]{"ecdsa-sha2-nistp256", "ssh-ed25519", "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp384", "rsa-sha2-256", "rsa-sha2-512", "ssh-rsa", "ssh-dss"}, testCase.getPreferredServerHostkeyAlgorithmOrder("localhost"));
     }
 
     @Test

--- a/test/com/trilead/ssh2/signature/RSAKeyAlgorithmTest.java
+++ b/test/com/trilead/ssh2/signature/RSAKeyAlgorithmTest.java
@@ -3,6 +3,8 @@ package com.trilead.ssh2.signature;
 import com.trilead.ssh2.crypto.PEMDecoder;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -12,6 +14,8 @@ import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -21,11 +25,26 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Michael Clarke
  */
+@RunWith(Parameterized.class)
 public class RSAKeyAlgorithmTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+                new Object[]{"SHA1WithRSA", "ssh-rsa"},
+                new Object[]{"SHA256withRSA", "rsa-sha2-256"},
+                new Object[]{"SHA512withRSA", "rsa-sha2-512"}
+        );
+    }
+
+    private final RSAKeyAlgorithm testCase;
+
+    public RSAKeyAlgorithmTest(String signatureAlgorithm, String keyFormat) {
+        testCase = new RSAKeyAlgorithm(signatureAlgorithm, keyFormat);
+    }
 
     @Test
     public void testEncodeDecodePublicKey() throws GeneralSecurityException, IOException {
-        RSAKeyAlgorithm testCase = new RSAKeyAlgorithm();
         KeyPairGenerator factory = KeyPairGenerator.getInstance("RSA");
         RSAPublicKey publicKey = (RSAPublicKey) factory.generateKeyPair().getPublic();
         byte[] encoded = testCase.encodePublicKey(publicKey);
@@ -35,7 +54,6 @@ public class RSAKeyAlgorithmTest {
 
     @Test
     public void testEncodeDecodeSignature() throws GeneralSecurityException, IOException {
-        RSAKeyAlgorithm testCase = new RSAKeyAlgorithm();
         KeyPairGenerator factory = KeyPairGenerator.getInstance("RSA");
         RSAPrivateKey privateKey = (RSAPrivateKey) factory.generateKeyPair().getPrivate();
         byte[] signature = testCase.generateSignature("Sign Me".getBytes(StandardCharsets.UTF_8), privateKey, new SecureRandom());
@@ -46,7 +64,6 @@ public class RSAKeyAlgorithmTest {
 
     @Test
     public void testSignAndVerify() throws GeneralSecurityException, IOException {
-        RSAKeyAlgorithm testCase = new RSAKeyAlgorithm();
         byte[] message = "Signature Test".getBytes(StandardCharsets.UTF_8);
         KeyPairGenerator factory = KeyPairGenerator.getInstance("RSA");
         KeyPair keyPair = factory.generateKeyPair();
@@ -59,7 +76,6 @@ public class RSAKeyAlgorithmTest {
 
     @Test
     public void testSignAndVerifyFailure() throws GeneralSecurityException, IOException {
-        RSAKeyAlgorithm testCase = new RSAKeyAlgorithm();
         byte[] message = "Signature Test 2".getBytes(StandardCharsets.UTF_8);
         KeyPairGenerator factory = KeyPairGenerator.getInstance("RSA");
         KeyPair keyPair = factory.generateKeyPair();


### PR DESCRIPTION
This adds support for the two new key algorithms specified in RFC 8332: RSA with SHA-256 and SHA-512. These still use the same key format as the SHA-1 variant (ssh-rsa), though the signature names are updated to rsa-sha2-256 and rsa-sha2-512.

Tested with OpenSSH 8.1p1 on macOS and with the Docker images. Locally, I configured sshd to only allow `HostKeyAlgorithms rsa-sha2-512,rsa-sha2-256` which forced the client to use one of the two added algorithms. This worked after I updated my known hosts file accordingly which was previously defaulting to ECDSA (tested with SSH Build Agents plugin in Jenkins master).

Compare to #43 which initially tried to implement this incorrectly.

Signed-off-by: Matt Sicker <boards@gmail.com>

@jeffret-b @Wadeck @daniel-beck 