### PR TITLE
ci: grab correct incremental artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,13 +29,23 @@ pipeline {
              }
              post {
                  always {
+                    /*
                      archiveArtifacts(allowEmptyArchive: true,
                          artifacts: "**/target/trilead*.jar",
                          onlyIfSuccessful: false)
+                     */
                      junit(allowEmptyResults: true,
                          keepLongStdio: true,
                          testResults: "**/target/surefire-reports/**/*.xml")
                      script {
+                        // MINSTALL-126 would make this easier by letting us publish to a different directory to begin with:
+                        String m2repo = sh script: 'mvn -Dset.changelist -Dexpression=settings.localRepository -q -DforceStdout help:evaluate', returnStdout: true
+                        // No easy way to load both of these in one command: https://stackoverflow.com/q/23521889/12916
+                        String version = sh script: 'mvn -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate', returnStdout: true
+                        echo "Collecting $version from $m2repo for possible Incrementals publishing"
+                        dir(m2repo) {
+                            archiveArtifacts "org/jenkins-ci/trilead-ssh2/$version/*$version*"
+                        }
                         infra.maybePublishIncrementals()
                      }
                  }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,8 +38,7 @@ pipeline {
                          keepLongStdio: true,
                          testResults: "**/target/surefire-reports/**/*.xml")
                      script {
-                        // MINSTALL-126 would make this easier by letting us publish to a different directory to begin with:
-                        String m2repo = sh script: 'mvn -Dset.changelist -Dexpression=settings.localRepository -q -DforceStdout help:evaluate', returnStdout: true
+                        def m2repo = "${pwd tmp: true}/m2repo"
                         // No easy way to load both of these in one command: https://stackoverflow.com/q/23521889/12916
                         String version = sh script: 'mvn -Dset.changelist -Dexpression=project.version -q -DforceStdout help:evaluate', returnStdout: true
                         echo "Collecting $version from $m2repo for possible Incrementals publishing"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                  always {
                     /*
                      archiveArtifacts(allowEmptyArchive: true,
-                         artifacts: "**/target/trilead*.jar",
+                         artifacts: "** /target/trilead*.jar",
                          onlyIfSuccessful: false)
                      */
                      junit(allowEmptyResults: true,


### PR DESCRIPTION
The artifacts are not got by the incremental process because are not in the correct place. I cannot use the default implementation of prepareToPublishIncrementals because it gives me the following error due the .m2 folder used is the system .m2 and contains tons of artifacts.

```
22:22:27  Archiving artifacts
22:22:27  java.lang.InterruptedException: no matches found within 10000
22:22:27  	at hudson.FilePath$ValidateAntFileMask.hasMatch(FilePath.java:2865)
22:22:27  	at hudson.FilePath$ValidateAntFileMask.invoke(FilePath.java:2744)
22:22:27  	at hudson.FilePath$ValidateAntFileMask.invoke(FilePath.java:2725)
22:22:27  	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3112)
22:22:27  Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to EC2 (aws) - High memory ubuntu 18.04  (i-0f6f4269e566d8d4a)
22:22:27  		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1800)
22:22:27  		at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:357)
22:22:27  		at hudson.remoting.Channel.call(Channel.java:1001)
22:22:27  		at hudson.FilePath.act(FilePath.java:1070)
22:22:28  		at hudson.FilePath.act(FilePath.java:1059)
22:22:28  		at hudson.FilePath.validateAntFileMask(FilePath.java:2723)
22:22:28  		at hudson.tasks.ArtifactArchiver.perform(ArtifactArchiver.java:270)
22:22:28  		at jdk.internal.reflect.GeneratedMethodAccessor1377.invoke(Unknown Source)
22:22:28  		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
22:22:28  		at java.base/java.lang.reflect.Method.invoke(Method.java:566)
22:22:28  		at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:92)
22:22:28  		at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:70)
22:22:28  		at 
```