### PR TITLE
fix: remove slf4j warnings from logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,12 @@
       <version>1.14.3</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-nop</artifactId>
+          <version>1.7.30</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
remove to warning messages from test logs

https://www.slf4j.org/codes.html#StaticLoggerBinder
https://www.slf4j.org/codes.html#no_static_mdc_binder

