### PR TITLE
test: bump testcontainers version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.14.3</version>
+      <version>1.16.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
For a while there are two tests that fail to start the test container ryuk Docker container, this PR is trying to fix it.


```
org.testcontainers.containers.ContainerLaunchException: Container startup failed
Caused by: org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=jenkins/ssh-agent:latest, imagePullPolicy=DefaultPullPolicy())
Caused by: com.github.dockerjava.api.exception.NotFoundException: 
{"message":"No such image: testcontainersofficial/ryuk:0.3.0"}
```

