### PR TITLE
Removal of unnecessary protobuf-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,12 +106,12 @@
             <groupId>com.google.crypto.tink</groupId>
             <artifactId>tink</artifactId>
             <version>1.6.1</version>
-        </dependency>
-        <!-- TODO check if we can exclude protobuf -->
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.21.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
In my company we use trilead with protobuf-java excluded and it been working fine, (we use all of the KEX algorithms #60 which is the reason why tink was added and indirectly protobuf-java  )


