### PR TITLE
Update parent POM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,11 +17,9 @@ pipeline {
                             '--update-snapshots',
                             "-Dmaven.repo.local=$m2repo",
                             '-Dmaven.test.failure.ignore',
-                            "-Dspotbugs.failOnError=false",
                             "-Dset.changelist",
                             "-Djava.security.egd=file:/dev/./urandom",
-                            "clean install",
-                            "spotbugs:spotbugs"
+                            "clean install"
                     ]
 
                     infra.runMaven(mavenOptions, jdk)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>jenkins</artifactId>
-        <version>1.90</version>
+        <version>1.91</version>
     </parent>
 
     <groupId>org.jenkins-ci</groupId>
@@ -37,7 +37,7 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
@@ -67,30 +67,17 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
+            <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.8.1</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.java.dev.jna</groupId>
-                    <artifactId>jna</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.java.dev.jna</groupId>
-                    <artifactId>jna-platform</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.i2p.crypto</groupId>
@@ -166,7 +153,8 @@
         <revision>build-217-jenkins</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/trilead-ssh2</gitHubRepo>
-        <java.level>8</java.level>
+        <!-- TODO fix medium-threshold violations -->
+        <spotbugs.threshold>High</spotbugs.threshold>
     </properties>
 
 </project>

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!--
+    Here lies technical debt. Exclusions in this section have not yet been triaged. When working on
+    on this section, pick an exclusion to triage, then:
+    - If it is a false positive, add a @SuppressFBWarnings(value = "[…]", justification = "[…]")
+      annotation indicating the reason why it is a false positive, then remove the exclusion from
+      this section.
+    - If it is not a false positive, fix the bug, then remove the exclusion from this section.
+   -->
+  <Match>
+    <Confidence value="1"/>
+    <Or>
+      <And>
+        <Bug pattern="DM_BOXED_PRIMITIVE_FOR_PARSING"/>
+        <Or>
+          <Class name="com.trilead.ssh2.auth.AuthenticationManager"/>
+          <Class name="com.trilead.ssh2.channel.ChannelManager"/>
+        </Or>
+      </And>
+      <And>
+        <Bug pattern="DM_DEFAULT_ENCODING"/>
+        <Or>
+          <Class name="com.trilead.ssh2.Connection"/>
+          <Class name="com.trilead.ssh2.crypto.dh.GenericDhExchange"/>
+          <Class name="com.trilead.ssh2.KnownHosts"/>
+          <Class name="com.trilead.ssh2.packets.TypesReader"/>
+          <Class name="com.trilead.ssh2.packets.TypesWriter"/>
+          <Class name="com.trilead.ssh2.transport.ClientServerHello"/>
+        </Or>
+      </And>
+      <And>
+        <Bug pattern="RV_EXCEPTION_NOT_THROWN"/>
+        <Class name="com.trilead.ssh2.crypto.PEMDecoder"/>
+      </And>
+      <And>
+        <Bug pattern="WEAK_MESSAGE_DIGEST_MD5"/>
+        <Class name="com.trilead.ssh2.crypto.PEMDecoder"/>
+      </And>
+    </Or>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
Updates the parent POM and adapts to recent parent POM changes by removing explicit SpotBugs configuration and unnecessary version numbers that are already managed in the parent POM. Rather than solving all SpotBugs violations I simply suppressed any existing violations at the build level so that they do not cause problems for CI runs and that so fixes to particular SpotBugs violations can be tested locally the same way they would be tested in CI.