### PR TITLE
Giving threads names for easier troubleshooting

### DIFF
--- a/src/com/trilead/ssh2/transport/TransportManager.java
+++ b/src/com/trilead/ssh2/transport/TransportManager.java
@@ -64,7 +64,13 @@ public class TransportManager
 
 	private final Vector asynchronousQueue = new Vector();
 	private Thread asynchronousThread = null;
-
+	
+	/* For auto numbering threads. */
+	private static long threadInitNumber;
+	private synchronized String nextThreadName(String prefix) {
+		return "Trilead_TransportManager_" + prefix + "_" + hostname +":" + port + "_" + threadInitNumber++;
+	}
+	
 	class AsynchronousWorker extends Thread
 	{
 		public void run()
@@ -542,6 +548,7 @@ public class TransportManager
 		});
 
 		receiveThread.setDaemon(true);
+		receiveThread.setName(nextThreadName("receiveThread"));
 		receiveThread.start();
 	}
 
@@ -646,6 +653,7 @@ public class TransportManager
 			{
 				asynchronousThread = new AsynchronousWorker();
 				asynchronousThread.setDaemon(true);
+				asynchronousThread.setName(nextThreadName("sendThread"));
 				asynchronousThread.start();
 
 				/* The thread will stop after 2 seconds of inactivity (i.e., empty queue) */


### PR DESCRIPTION
We ran into an issue were we had hundreds of Trilead threads simply using the default names Thread-1....Thread-250

With this change it would be very easy to identify to what library and connection a thread belongs to.
