### PR TITLE
TimeoutService threads are left after closing connection

### DIFF
--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -665,7 +665,7 @@ public class Connection
 		if (kexTimeout < 0)
 			throw new IllegalArgumentException("kexTimeout must be non-negative!");
 
-		final TimeoutState state = new TimeoutState():		    
+		final TimeoutState state = new TimeoutState();		    
 		final TimeoutService timeoutService = new TimeoutService(hostname);		    
 
 		tm = new TransportManager(hostname, port, sourceAddress);

--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -665,7 +665,8 @@ public class Connection
 		if (kexTimeout < 0)
 			throw new IllegalArgumentException("kexTimeout must be non-negative!");
 
-		final TimeoutState state = new TimeoutState();
+		final TimeoutState state = new TimeoutState():		    
+		final TimeoutService timeoutService = new TimeoutService(hostname);		    
 
 		tm = new TransportManager(hostname, port, sourceAddress);
 		
@@ -713,7 +714,7 @@ public class Connection
 
 					long timeoutHorizont = System.currentTimeMillis() + kexTimeout;
 
-					token = TimeoutService.addTimeoutHandler(timeoutHorizont, timeoutHandler);
+					token = timeoutService.addTimeoutHandler(timeoutHorizont, timeoutHandler);
 				}
 
 				try
@@ -737,7 +738,7 @@ public class Connection
 
 				if (token != null)
 				{
-					TimeoutService.cancelTimeoutHandler(token);
+					timeoutService.cancelTimeoutHandler(token);
 
 					/* Were we too late? */
 


### PR DESCRIPTION
See [JENKINS-71798](https://issues.jenkins.io/browse/JENKINS-71798).

Fix has been verified in customers environment
