### PR TITLE
chore: test and compile with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             steps {
                 script {
                     m2repo = "${pwd tmp: true}/m2repo"
-                    String jdk = "17"
+                    String jdk = "21"
                     List<String> mavenOptions = [
                             '--update-snapshots',
                             "-Dmaven.repo.local=$m2repo",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             steps {
                 script {
                     m2repo = "${pwd tmp: true}/m2repo"
-                    String jdk = "21"
+                    String jdk = "17"
                     List<String> mavenOptions = [
                             '--update-snapshots',
                             "-Dmaven.repo.local=$m2repo",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             steps {
                 script {
                     m2repo = "${pwd tmp: true}/m2repo"
-                    String jdk = "11"
+                    String jdk = "17"
                     List<String> mavenOptions = [
                             '--update-snapshots',
                             "-Dmaven.repo.local=$m2repo",

--- a/test/com/trilead/ssh2/KnownHostsTest.java
+++ b/test/com/trilead/ssh2/KnownHostsTest.java
@@ -43,6 +43,7 @@ public class KnownHostsTest {
     public void testKnownHostsPreferredAlgorithmsEcdsaOnly() throws IOException, NoSuchAlgorithmException {
         KnownHosts testCase = new KnownHosts();
         KeyPairGenerator ecGenerator = KeyPairGenerator.getInstance("EC");
+        ecGenerator.initialize(256);
         testCase.addHostkey(new String[]{"localhost"}, "ecdsa-sha2-nistp256", new ECDSAKeyAlgorithm.ECDSASha2Nistp256().encodePublicKey((ECPublicKey) ecGenerator.generateKeyPair().getPublic()));
         assertArrayEquals(new String[]{"ecdsa-sha2-nistp256", "ssh-ed25519", "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp384","rsa-sha2-256", "rsa-sha2-512","ssh-rsa", "ssh-dss"}, testCase.getPreferredServerHostkeyAlgorithmOrder("localhost"));
     }


### PR DESCRIPTION
## Test with Java 21

Java 21 released Sep 19, 2023. We'd like to announce full support for Java 21 in early October and would like the most used plugins to be compiling and testing with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

Java 11 will be unsupported by Eclipse Temurin and some other Java providers in October 2024. We'll need to move past Java 11 by that time. It does not change the supported Java version or the byte code that is being generated.

This intentionally does not include Java 11 in the test configuration because Java 11 byte code is being generated by the Java 17 and Java 21 compilation and because Java 11 is being tested at least weekly by the plugin bill of materials.

Let's save the expense of testing Java 11 on ci.jenkins.io and rely on the existing tests (bom) of Java 11 and the Java 17 and Java 21 tests that run with Java 11 byte code.

### Submitter checklist

- [x] [JIRA issue](https://issues.jenkins.io/browse/JENKINS-71800) is well described 
- [x] Appropriate autotests or explanation to why this change has no tests
