### PR TITLE
Adding timeouts to wait methods, to never allow for infinite wait() state.

### DIFF
--- a/src/com/trilead/ssh2/StreamGobbler.java
+++ b/src/com/trilead/ssh2/StreamGobbler.java
@@ -141,7 +141,7 @@ public class StreamGobbler extends InputStream
 
 				try
 				{
-					synchronizer.wait();
+					synchronizer.wait(30*60*1000);
 				}
 				catch (InterruptedException e)
 				{
@@ -210,7 +210,7 @@ public class StreamGobbler extends InputStream
 
 				try
 				{
-					synchronizer.wait();
+					synchronizer.wait(30*60*1000);
 				}
 				catch (InterruptedException e)
 				{

--- a/src/com/trilead/ssh2/StreamGobbler.java
+++ b/src/com/trilead/ssh2/StreamGobbler.java
@@ -35,6 +35,10 @@ import java.io.InterruptedIOException;
 
 public class StreamGobbler extends InputStream
 {
+
+	private static final String PROPERTY_TIMEOUT = StreamGobbler.class.getName() + ".timeout";
+	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"120000"));
+
 	class GobblerThread extends Thread
 	{
 		public void run()
@@ -141,7 +145,7 @@ public class StreamGobbler extends InputStream
 
 				try
 				{
-					synchronizer.wait(30*60*1000);
+					synchronizer.wait(DEFAULT_WAIT_TIMEOUT);
 				}
 				catch (InterruptedException e)
 				{
@@ -210,7 +214,7 @@ public class StreamGobbler extends InputStream
 
 				try
 				{
-					synchronizer.wait(30*60*1000);
+					synchronizer.wait(DEFAULT_WAIT_TIMEOUT);
 				}
 				catch (InterruptedException e)
 				{

--- a/src/com/trilead/ssh2/StreamGobbler.java
+++ b/src/com/trilead/ssh2/StreamGobbler.java
@@ -37,7 +37,7 @@ public class StreamGobbler extends InputStream
 {
 
 	private static final String PROPERTY_TIMEOUT = StreamGobbler.class.getName() + ".timeout";
-	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"120000"));
+	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 
 	class GobblerThread extends Thread
 	{

--- a/src/com/trilead/ssh2/StreamGobbler.java
+++ b/src/com/trilead/ssh2/StreamGobbler.java
@@ -37,7 +37,7 @@ public class StreamGobbler extends InputStream
 {
 
 	private static final String PROPERTY_TIMEOUT = StreamGobbler.class.getName() + ".timeout";
-	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
+	private static long DEFAULT_WAIT_TIMEOUT = Long.parseLong(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 
 	class GobblerThread extends Thread
 	{

--- a/src/com/trilead/ssh2/auth/AuthenticationManager.java
+++ b/src/com/trilead/ssh2/auth/AuthenticationManager.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 public class AuthenticationManager implements MessageHandler
 {
 	public static final String PROPERTY_TIMEOUT = AuthenticationManager.class.getName() + ".timeout";
-	public static final long TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"120000"));
+	public static final long TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 	TransportManager tm;
 
 	Vector packets = new Vector();

--- a/src/com/trilead/ssh2/auth/AuthenticationManager.java
+++ b/src/com/trilead/ssh2/auth/AuthenticationManager.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 public class AuthenticationManager implements MessageHandler
 {
 	public static final String PROPERTY_TIMEOUT = AuthenticationManager.class.getName() + ".timeout";
-	public static final long TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
+	public static final long TIMEOUT = Long.parseLong(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 	TransportManager tm;
 
 	Vector packets = new Vector();

--- a/src/com/trilead/ssh2/channel/ChannelManager.java
+++ b/src/com/trilead/ssh2/channel/ChannelManager.java
@@ -382,7 +382,7 @@ public class ChannelManager implements MessageHandler
 
 					try
 					{
-						c.wait(30*60*1000);
+						c.wait(DEFAULT_WAIT_TIMEOUT);
 					}
 					catch (InterruptedException ignore)
 					{
@@ -913,7 +913,7 @@ public class ChannelManager implements MessageHandler
                 if (timeout > 0)
                     c.wait(timeout);
                 else
-                    c.wait(30*60*1000);
+                    c.wait(DEFAULT_WAIT_TIMEOUT);
 			}
 		}
 	}

--- a/src/com/trilead/ssh2/channel/ChannelManager.java
+++ b/src/com/trilead/ssh2/channel/ChannelManager.java
@@ -38,7 +38,7 @@ public class ChannelManager implements MessageHandler
 {
 	private static final Logger log = Logger.getLogger(ChannelManager.class);
 	private static final String PROPERTY_TIMEOUT = ChannelManager.class.getName() + ".timeout";
-	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
+	private static long DEFAULT_WAIT_TIMEOUT = Long.parseLong(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 
 	private HashMap x11_magic_cookies = new HashMap();
 

--- a/src/com/trilead/ssh2/channel/ChannelManager.java
+++ b/src/com/trilead/ssh2/channel/ChannelManager.java
@@ -38,7 +38,7 @@ public class ChannelManager implements MessageHandler
 {
 	private static final Logger log = Logger.getLogger(ChannelManager.class);
 	private static final String PROPERTY_TIMEOUT = ChannelManager.class.getName() + ".timeout";
-	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"120000"));
+	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 
 	private HashMap x11_magic_cookies = new HashMap();
 

--- a/src/com/trilead/ssh2/channel/ChannelManager.java
+++ b/src/com/trilead/ssh2/channel/ChannelManager.java
@@ -382,7 +382,7 @@ public class ChannelManager implements MessageHandler
 
 					try
 					{
-						c.wait();
+						c.wait(30*60*1000);
 					}
 					catch (InterruptedException ignore)
 					{
@@ -913,7 +913,7 @@ public class ChannelManager implements MessageHandler
                 if (timeout > 0)
                     c.wait(timeout);
                 else
-                    c.wait();
+                    c.wait(30*60*1000);
 			}
 		}
 	}

--- a/src/com/trilead/ssh2/channel/FifoBuffer.java
+++ b/src/com/trilead/ssh2/channel/FifoBuffer.java
@@ -20,7 +20,7 @@ import java.io.OutputStream;
 class FifoBuffer {
 
 	private static final String PROPERTY_TIMEOUT = FifoBuffer.class.getName() + ".timeout";
-	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
+	private static long DEFAULT_WAIT_TIMEOUT = Long.parseLong(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 
     /**
      * Unit of buffer, singly linked and lazy created as needed.

--- a/src/com/trilead/ssh2/channel/FifoBuffer.java
+++ b/src/com/trilead/ssh2/channel/FifoBuffer.java
@@ -18,6 +18,10 @@ import java.io.OutputStream;
  * @author Kohsuke Kawaguchi
  */
 class FifoBuffer {
+
+	private static final String PROPERTY_TIMEOUT = FifoBuffer.class.getName() + ".timeout";
+	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"120000"));
+
     /**
      * Unit of buffer, singly linked and lazy created as needed.
      */
@@ -153,7 +157,7 @@ class FifoBuffer {
 
             synchronized (lock) {
                 while ((chunk = Math.min(len,writable()))==0)
-                    lock.wait(30*60*1000);
+                    lock.wait(DEFAULT_WAIT_TIMEOUT);
 
                 w.write(buf, start, chunk);
 
@@ -209,7 +213,7 @@ class FifoBuffer {
                         releaseRing();
                         return -1;  // no more data
                     }
-                    lock.wait(12*60*60*1000); // wait until the writer gives us something
+                    lock.wait(DEFAULT_WAIT_TIMEOUT); // wait until the writer gives us something
                 }
 
                 r.read(buf,start,chunk);

--- a/src/com/trilead/ssh2/channel/FifoBuffer.java
+++ b/src/com/trilead/ssh2/channel/FifoBuffer.java
@@ -20,7 +20,7 @@ import java.io.OutputStream;
 class FifoBuffer {
 
 	private static final String PROPERTY_TIMEOUT = FifoBuffer.class.getName() + ".timeout";
-	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"120000"));
+	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 
     /**
      * Unit of buffer, singly linked and lazy created as needed.

--- a/src/com/trilead/ssh2/channel/FifoBuffer.java
+++ b/src/com/trilead/ssh2/channel/FifoBuffer.java
@@ -153,7 +153,7 @@ class FifoBuffer {
 
             synchronized (lock) {
                 while ((chunk = Math.min(len,writable()))==0)
-                    lock.wait();
+                    lock.wait(30*60*1000);
 
                 w.write(buf, start, chunk);
 
@@ -209,7 +209,7 @@ class FifoBuffer {
                         releaseRing();
                         return -1;  // no more data
                     }
-                    lock.wait(); // wait until the writer gives us something
+                    lock.wait(12*60*60*1000); // wait until the writer gives us something
                 }
 
                 r.read(buf,start,chunk);

--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -98,7 +98,7 @@ public class KexManager implements MessageHandler
 
 				try
 				{
-					accessLock.wait();
+					accessLock.wait(30*60*1000);
 				}
 				catch (InterruptedException e)
 				{

--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -46,7 +46,7 @@ public class KexManager implements MessageHandler
 {
 	private static final Logger log = Logger.getLogger(KexManager.class);
 	private static final String PROPERTY_TIMEOUT = KexManager.class.getName() + ".timeout";
-	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
+	private static long DEFAULT_WAIT_TIMEOUT = Long.parseLong(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 
 	private static final List<String> DEFAULT_KEY_ALGORITHMS = buildDefaultKeyAlgorithms();
 

--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -46,7 +46,7 @@ public class KexManager implements MessageHandler
 {
 	private static final Logger log = Logger.getLogger(KexManager.class);
 	private static final String PROPERTY_TIMEOUT = KexManager.class.getName() + ".timeout";
-	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"120000"));
+	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 
 	private static final List<String> DEFAULT_KEY_ALGORITHMS = buildDefaultKeyAlgorithms();
 

--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -45,6 +45,8 @@ import com.trilead.ssh2.signature.KeyAlgorithmManager;
 public class KexManager implements MessageHandler
 {
 	private static final Logger log = Logger.getLogger(KexManager.class);
+	private static final String PROPERTY_TIMEOUT = KexManager.class.getName() + ".timeout";
+	private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"120000"));
 
 	private static final List<String> DEFAULT_KEY_ALGORITHMS = buildDefaultKeyAlgorithms();
 
@@ -98,7 +100,7 @@ public class KexManager implements MessageHandler
 
 				try
 				{
-					accessLock.wait(30*60*1000);
+					accessLock.wait(DEFAULT_WAIT_TIMEOUT);
 				}
 				catch (InterruptedException e)
 				{

--- a/src/com/trilead/ssh2/transport/TransportManager.java
+++ b/src/com/trilead/ssh2/transport/TransportManager.java
@@ -54,6 +54,8 @@ import com.trilead.ssh2.util.Tokenizer;
 public class TransportManager
 {
     private static final Logger log = Logger.getLogger(TransportManager.class);
+    private static final String PROPERTY_TIMEOUT = TransportManager.class.getName() + ".timeout";
+    private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"120000"));
 
     class HandlerEntry
 	{
@@ -87,7 +89,7 @@ public class TransportManager
 
 						try
 						{
-							asynchronousQueue.wait(2000);
+							asynchronousQueue.wait(DEFAULT_WAIT_TIMEOUT);
 						}
 						catch (InterruptedException e)
 						{
@@ -685,7 +687,7 @@ public class TransportManager
 
 				try
 				{
-					connectionSemaphore.wait(30*60*1000);
+					connectionSemaphore.wait(DEFAULT_WAIT_TIMEOUT);
 				}
 				catch (InterruptedException e)
 				{

--- a/src/com/trilead/ssh2/transport/TransportManager.java
+++ b/src/com/trilead/ssh2/transport/TransportManager.java
@@ -55,7 +55,7 @@ public class TransportManager
 {
     private static final Logger log = Logger.getLogger(TransportManager.class);
     private static final String PROPERTY_TIMEOUT = TransportManager.class.getName() + ".timeout";
-    private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"120000"));
+    private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 
     class HandlerEntry
 	{

--- a/src/com/trilead/ssh2/transport/TransportManager.java
+++ b/src/com/trilead/ssh2/transport/TransportManager.java
@@ -685,7 +685,7 @@ public class TransportManager
 
 				try
 				{
-					connectionSemaphore.wait();
+					connectionSemaphore.wait(30*60*1000);
 				}
 				catch (InterruptedException e)
 				{

--- a/src/com/trilead/ssh2/transport/TransportManager.java
+++ b/src/com/trilead/ssh2/transport/TransportManager.java
@@ -55,7 +55,7 @@ public class TransportManager
 {
     private static final Logger log = Logger.getLogger(TransportManager.class);
     private static final String PROPERTY_TIMEOUT = TransportManager.class.getName() + ".timeout";
-    private static long DEFAULT_WAIT_TIMEOUT = Long.valueOf(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
+    private static long DEFAULT_WAIT_TIMEOUT = Long.parseLong(System.getProperty(PROPERTY_TIMEOUT,"1200000"));
 
     class HandlerEntry
 	{


### PR DESCRIPTION
In a couple of important methods the Object.wait() is invoked without any timeout, which in some cases produces threads waiting forever. I've added default timeout of 30mins, in one case of 12h. I'm open to any other timeouts as long as it's not measured in days. It'd be better to have them as some variable as is already done in some cases with e.g.: DEFAULT_WAIT_TIMEOUT, but I left it as just plain values for now, to discuss about the value for the wait(), and then set it as variable.

See [JENKINS-73575](https://issues.jenkins.io/browse/JENKINS-73575).

I believe that when something is wrong with the process it should communicate and not stay in the background wasting resources never to do anything again. This update may create some new issues with regards to problems with agents connectivity, where before Jenkins would just forever try to reconnect, even though the agent stopped existing, and now it would just raise error, as in any other case.

The tests for this would be incredibly hard to perform as the situations where such infinite wait() happens are very specific and I was not able to replicate them so far.

### Submitter checklist

- [X] JIRA issue is well described
- [X] Appropriate autotests or explanation to why this change has no tests

