### PR TITLE
 Revert timeout back 2000ms instead of 1200000ms in TransportManager.java

### DIFF
--- a/src/com/trilead/ssh2/transport/TransportManager.java
+++ b/src/com/trilead/ssh2/transport/TransportManager.java
@@ -90,7 +90,7 @@ public class TransportManager
 
 						try
 						{
-							asynchronousQueue.wait(DEFAULT_WAIT_TIMEOUT);
+							asynchronousQueue.wait(2000);
 						}
 						catch (InterruptedException e)
 						{


### PR DESCRIPTION
Recent one specific change to a timeout that is causing some SSH sessions, to timeout because of inactivity.
Revert is just for one seemingly unintended change from: #198 
@Experrior 

Commands that worked without issues in our enviroment previously but not anylonger: sleep 120s
but it was working fine with:
asynchronousQueue.wait(2000);
but not with the new:
asynchronousQueue.wait(DEFAULT_WAIT_TIMEOUT); //1200000ms

Notice the even the comment was left: /* After the queue is empty for about 2 seconds, stop this thread */ I think it was a mistake to change this specific wait() with to a different timeout. as the pullrequest seems to want to introduce a default timeout to the wait() with infinite timeouts. 


https://github.com/jenkinsci/trilead-ssh2/commit/15622af005d77be07a89c29bb7e7565af72f33c9#diff-fbe5f13c040cb16dee69517cb436e446fa38cfb3262e690cc711f52a32edda75R92

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

@
