### PR TITLE
Update SFTPv3Client.java, openFile public

### DIFF
--- a/src/com/trilead/ssh2/SFTPv3Client.java
+++ b/src/com/trilead/ssh2/SFTPv3Client.java
@@ -1162,7 +1162,7 @@ public class SFTPv3Client
 	 * SSH_FXF_TRUNC,SSH_FXF_EXCL found at: https://www.ietf.org/proceedings/50/I-D/secsh-filexfer-00.txt
 	 * 
 	 * @param fileName See the {@link SFTPv3Client comment} for the class for more details.
-         * @param int flags SSH_FXF_READ,SSH_FXF_WRITE,SSH_FXF_APPEND,SSH_FXF_CREAT,
+         * @param flags SSH_FXF_READ,SSH_FXF_WRITE,SSH_FXF_APPEND,SSH_FXF_CREAT,
 	 *                  SSH_FXF_TRUNC,SSH_FXF_EXCL
 	 * @param attr may be <code>null</code> to use server defaults. Probably only
 	 *             the <code>uid</code>, <code>gid</code> and <code>permissions</code>

--- a/src/com/trilead/ssh2/SFTPv3Client.java
+++ b/src/com/trilead/ssh2/SFTPv3Client.java
@@ -1088,7 +1088,7 @@ public class SFTPv3Client
 	}
 
 	/**
-	 * reate a file (truncate it if it already exists) and open it for reading and writing.
+	 * Create a file (truncate it if it already exists) and open it for reading and writing.
 	 * You can specify the default attributes of the file (the server may or may
 	 * not respect your wishes).
 	 * 
@@ -1154,7 +1154,25 @@ public class SFTPv3Client
 		return tw.getBytes();
 	}
 
-	private SFTPv3FileHandle openFile(String fileName, int flags, SFTPv3FileAttributes attr) throws IOException
+
+	/**
+	 * Prefer usage of createFileTruncate,openFileRO,openFileRW and similar.  
+         * Only use this method when you need full control over what should happen.
+         * This method allows Or(|) together SSH_FXF_READ,SSH_FXF_WRITE,SSH_FXF_APPEND,SSH_FXF_CREAT,
+	 * SSH_FXF_TRUNC,SSH_FXF_EXCL found at: https://www.ietf.org/proceedings/50/I-D/secsh-filexfer-00.txt
+	 * 
+	 * @param fileName See the {@link SFTPv3Client comment} for the class for more details.
+         * @param int flags SSH_FXF_READ,SSH_FXF_WRITE,SSH_FXF_APPEND,SSH_FXF_CREAT,
+	 *                  SSH_FXF_TRUNC,SSH_FXF_EXCL
+	 * @param attr may be <code>null</code> to use server defaults. Probably only
+	 *             the <code>uid</code>, <code>gid</code> and <code>permissions</code>
+	 *             (remember the server may apply a umask) entries of the {@link SFTPv3FileHandle}
+	 *             structure make sense. You need only to set those fields where you want
+	 *             to override the server's defaults.
+	 * @return a SFTPv3FileHandle handle
+	 * @throws IOException the io exception
+	 */
+	public SFTPv3FileHandle openFile(String fileName, int flags, SFTPv3FileAttributes attr) throws IOException
 	{
 		int req_id = generateNextRequestID();
 


### PR DESCRIPTION
Current public APIs for open calls are issued with these flags: SSH_FXF_READ|SSH_FXF_WRITE|SSH_FXF_CREAT|SSH_FXF_TRUNC, i.e. for both reading and writing simultaneously.  due to the way S3 works, this is not feasible to implement it(server) properly, as we would have to store somewhere the whole file being written be able to properly serve the read requests. this could require as much memory or disk volume space as the largest file to be written


I made the existing private method openFile()
public to allow finer control to the few  end users who need it.  


We intend to use it like:
openFile(fileName, 0x00000018 | 0x00000002, attr)
which is the same as existing createFileTruncate but without SSH_FXF_READ




- [x] Appropriate autotests or explanation to why this change has no tests
      I did not add anything new to be tested, just made a method more accessible.

