### PR TITLE
fix: Wait for service request message response

### DIFF
--- a/src/com/trilead/ssh2/auth/AuthenticationManager.java
+++ b/src/com/trilead/ssh2/auth/AuthenticationManager.java
@@ -141,11 +141,12 @@ public class AuthenticationManager implements MessageHandler
 			PacketServiceRequest sr = new PacketServiceRequest("ssh-userauth");
 			tm.sendMessage(sr.getPayload());
 
+			byte[] msg = getNextMessage();
+			new PacketServiceAccept(msg, 0, msg.length);
+
 			PacketUserauthRequestNone urn = new PacketUserauthRequestNone("ssh-connection", user);
 			tm.sendMessage(urn.getPayload());
 
-			byte[] msg = getNextMessage();
-			new PacketServiceAccept(msg, 0, msg.length);
 			msg = getNextMessage();
 
 			initDone = true;


### PR DESCRIPTION
Prior to this PR, the authentication code sent 'ssh-userauth' SSH_MSG_SERVICE_REQUEST followed by 'ssh-connection' SSH_MSG_USERAUTH_REQUEST before waiting for responses of both of these requests.

This seems to be a violation of the protocol which mentions (quoting the protocol RFC 4253 Section 8 "Service Request"):

"Note that after a key exchange with implicit server authentication, the client MUST wait for response to its service request message before sending any further data."

This pull request changes the code to wait for SSH_MSG_SERVICE_REQUEST response before sending the SSH_MSG_USERAUTH_REQUEST to adhere to the protocol.


See https://gitlab.com/libssh/libssh-mirror/-/issues/311
See [JENKINS-75919](https://issues.jenkins.io/browse/JENKINS-75919).

(Not adding any explicit tests, since I assume regression tests for ssh client would already be present ? Please correct me if they aren't)

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Appropriate autotests or explanation to why this change has no tests

